### PR TITLE
Generalize upstream addressing with AddressingConfig.

### DIFF
--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/AggregatorUpstream.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/AggregatorUpstream.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.HttpRequest
 import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
 import com.pagerduty.akka.http.proxy.Upstream
 
-trait AggregatorUpstream extends Upstream {
+trait AggregatorUpstream[AddressingConfig] extends Upstream[AddressingConfig] {
   def prepareAggregatorRequestForDelivery(
       authConfig: HeaderAuthConfig,
       request: HttpRequest,

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/Aggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/Aggregator.scala
@@ -4,8 +4,9 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import com.pagerduty.akka.http.aggregator.AggregatorUpstream
 import com.pagerduty.akka.http.requestauthentication.model.AuthenticationConfig
 
-trait Aggregator[RequestKey, AccumulatedState] {
-  type RequestMap = Map[RequestKey, (AggregatorUpstream, HttpRequest)]
+trait Aggregator[RequestKey, AccumulatedState, AddressingConfig] {
+  type RequestMap =
+    Map[RequestKey, (AggregatorUpstream[AddressingConfig], HttpRequest)]
   type ResponseMap = Map[RequestKey, (HttpResponse, String)]
   type ResponseHandler =
     (AccumulatedState, ResponseMap) => (AccumulatedState, RequestMap)

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepAggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepAggregator.scala
@@ -4,7 +4,8 @@ import akka.NotUsed
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import com.pagerduty.akka.http.requestauthentication.model.AuthenticationConfig
 
-trait OneStepAggregator[RequestKey] extends Aggregator[RequestKey, NotUsed] {
+trait OneStepAggregator[RequestKey, AddressingConfig]
+    extends Aggregator[RequestKey, NotUsed, AddressingConfig] {
   def handleIncomingRequest(
       authConfig: AuthenticationConfig
   )(incomingRequest: HttpRequest,

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepJsonHydrationAggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepJsonHydrationAggregator.scala
@@ -22,13 +22,14 @@ import ujson.Js
   * If any of these assumptions are untrue, look at using a supertype of this trait instead. Also, tell #core about your
   * use case!
   */
-trait OneStepJsonHydrationAggregator extends OneStepAggregator[String] {
+trait OneStepJsonHydrationAggregator[AddressingConfig]
+    extends OneStepAggregator[String, AddressingConfig] {
 
   // implement these two methods
   def handleIncomingRequestStateless(
       authConfig: AuthenticationConfig
   )(incomingRequest: HttpRequest, authData: authConfig.AuthData)
-    : Map[String, (AggregatorUpstream, HttpRequest)]
+    : Map[String, (AggregatorUpstream[AddressingConfig], HttpRequest)]
 
   def buildOutgoingJsonResponseStateless(
       upstreamJsonResponses: Map[String, (HttpResponse, Js.Value)])

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepAggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepAggregator.scala
@@ -1,7 +1,7 @@
 package com.pagerduty.akka.http.aggregator.aggregator
 
-trait TwoStepAggregator[RequestKey, AccumulatedState]
-    extends Aggregator[RequestKey, AccumulatedState] {
+trait TwoStepAggregator[RequestKey, AccumulatedState, AddressingConfig]
+    extends Aggregator[RequestKey, AccumulatedState, AddressingConfig] {
 
   def handleUpstreamResponses(
       initialState: AccumulatedState,

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepJsonHydrationAggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepJsonHydrationAggregator.scala
@@ -24,12 +24,14 @@ import ujson.Js
   * If any of these assumptions are untrue, look at using a supertype of this trait instead. Also, tell #core about your
   * use case!
   */
-trait TwoStepJsonHydrationAggregator
-    extends TwoStepAggregator[String, Either[HttpResponse, Js.Value]] {
+trait TwoStepJsonHydrationAggregator[AddressingConfig]
+    extends TwoStepAggregator[String,
+                              Either[HttpResponse, Js.Value],
+                              AddressingConfig] {
 
   // implement these three methods
-  def handleIncomingRequest(
-      incomingRequest: HttpRequest): (AggregatorUpstream, HttpRequest)
+  def handleIncomingRequest(incomingRequest: HttpRequest)
+    : (AggregatorUpstream[AddressingConfig], HttpRequest)
 
   def handleJsonUpstreamResponse(upstreamResponse: HttpResponse,
                                  upstreamJson: Js.Value): RequestMap

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/AggregatorUpstreamSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/AggregatorUpstreamSpec.scala
@@ -39,7 +39,7 @@ class AggregatorUpstreamSpec extends FreeSpecLike with Matchers {
 
   "AggregatorUpstream" - {
 
-    val u = new AggregatorUpstream {
+    val u = new AggregatorUpstream[String] {
       val metricsTag = "test"
       def addressRequest(request: HttpRequest,
                          localHostname: String): HttpRequest = ???

--- a/akka-http-auth-proxy/src/it/scala/com/pagerduty/akka/http/authproxy/support/HttpServer.scala
+++ b/akka-http-auth-proxy/src/it/scala/com/pagerduty/akka/http/authproxy/support/HttpServer.scala
@@ -11,7 +11,7 @@ import com.pagerduty.akka.http.headerauthentication.HeaderAuthenticator
 import com.pagerduty.akka.http.proxy.{
   ErrorHandling,
   HttpProxy,
-  LocalPortUpstream
+  CommonHostnameUpstream
 }
 import com.pagerduty.akka.http.requestauthentication.RequestAuthenticator
 
@@ -25,11 +25,11 @@ class HttpServer(
     val httpInterface: String,
     val port: Int,
     val servicePort: Int,
-    val httpProxy: HttpProxy
+    val httpProxy: HttpProxy[String]
 )(implicit actorSystem: ActorSystem,
   materializer: ActorMaterializer,
   val metrics: Metrics)
-    extends AuthProxyController[TestAuthConfig]
+    extends AuthProxyController[TestAuthConfig, String]
     with ErrorHandling { outer =>
 
   val log = LoggerFactory.getLogger(getClass)
@@ -47,11 +47,10 @@ class HttpServer(
     val requestAuthenticator = outer.requestAuthenticator
   }
 
-  val incidentUpstream = new LocalPortUpstream {
-    val localPort = servicePort
+  val incidentUpstream = new CommonHostnameUpstream {
+    val port = servicePort
     val metricsTag = "test"
   }
-  val localHostname = "localhost"
   val httpRoutes = {
 
     (handleExceptions(proxyExceptionHandler)) {

--- a/akka-http-auth-proxy/src/main/scala/com/pagerduty/akka/http/authproxy/AuthProxyController.scala
+++ b/akka-http-auth-proxy/src/main/scala/com/pagerduty/akka/http/authproxy/AuthProxyController.scala
@@ -8,28 +8,27 @@ import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
 import com.pagerduty.akka.http.proxy.{HttpProxy, Upstream}
 import com.pagerduty.akka.http.support.RequestMetadata
 
-trait AuthProxyController[AuthConfig <: HeaderAuthConfig] {
+trait AuthProxyController[AuthConfig <: HeaderAuthConfig, AddressingConfig] {
 
   val authConfig: AuthConfig
-  def httpProxy: HttpProxy
+  def httpProxy: HttpProxy[AddressingConfig]
   def headerAuthenticator: HeaderAuthenticator
-  def localHostname: String
 
   def prefixProxyRoute(
       path: PathMatcher[Unit],
-      upstream: Upstream,
+      upstream: Upstream[AddressingConfig],
       requestTransformer: HttpRequest => HttpRequest
   ): Route =
     prefixProxyRoute(path, upstream, None, Some(requestTransformer))
 
   def prefixProxyRoute(path: PathMatcher[Unit],
-                       upstream: Upstream,
+                       upstream: Upstream[AddressingConfig],
                        requiredPermission: AuthConfig#Permission): Route =
     prefixProxyRoute(path, upstream, Some(requiredPermission))
 
   def prefixProxyRoute(
       path: PathMatcher[Unit],
-      upstream: Upstream,
+      upstream: Upstream[AddressingConfig],
       requiredPermission: AuthConfig#Permission,
       requestTransformer: HttpRequest => HttpRequest
   ): Route =
@@ -40,7 +39,7 @@ trait AuthProxyController[AuthConfig <: HeaderAuthConfig] {
 
   def prefixProxyRoute(
       path: PathMatcher[Unit],
-      upstream: Upstream,
+      upstream: Upstream[AddressingConfig],
       requiredPermission: Option[AuthConfig#Permission] = None,
       requestTransformer: Option[HttpRequest => HttpRequest] = None,
       stripAuthorizationHeader: Boolean = true
@@ -52,23 +51,23 @@ trait AuthProxyController[AuthConfig <: HeaderAuthConfig] {
                  stripAuthorizationHeader)
     }
 
-  def proxyRoute(upstream: Upstream,
+  def proxyRoute(upstream: Upstream[AddressingConfig],
                  requiredPermission: AuthConfig#Permission): Route =
     proxyRoute(upstream, Some(requiredPermission))
 
-  def proxyRoute(upstream: Upstream,
+  def proxyRoute(upstream: Upstream[AddressingConfig],
                  requestTransformer: HttpRequest => HttpRequest): Route =
     proxyRoute(upstream, None, Some(requestTransformer))
 
   def proxyRoute(
-      upstream: Upstream,
+      upstream: Upstream[AddressingConfig],
       requiredPermission: AuthConfig#Permission,
       requestTransformer: HttpRequest => HttpRequest
   ): Route =
     proxyRoute(upstream, Some(requiredPermission), Some(requestTransformer))
 
   def proxyRoute(
-      upstream: Upstream,
+      upstream: Upstream[AddressingConfig],
       requiredPermission: Option[AuthConfig#Permission] = None,
       requestTransformer: Option[HttpRequest => HttpRequest] = None,
       stripAuthorizationHeader: Boolean = true
@@ -90,7 +89,7 @@ trait AuthProxyController[AuthConfig <: HeaderAuthConfig] {
     }
 
   private def proxyAuthenticatedRequest(
-      upstream: Upstream,
+      upstream: Upstream[AddressingConfig],
       request: HttpRequest,
       requiredPermission: Option[AuthConfig#Permission],
       stripAuthorizationHeader: Boolean

--- a/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/HttpProxy.scala
+++ b/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/HttpProxy.scala
@@ -14,17 +14,18 @@ object HttpProxy {
   val KeepAliveHeaderValue = "keep-alive"
 }
 
-class HttpProxy(
-    localHostname: String,
+class HttpProxy[AddressingConfig](
+    addressingConfig: AddressingConfig,
     httpClient: HttpRequest => Future[HttpResponse],
     proxyRequestModifier: Option[HttpRequest => HttpRequest] = None
 )(implicit ec: ExecutionContext, materializer: Materializer, metrics: Metrics)
     extends MetadataLogging {
   import HttpProxy._
 
-  def request(request: HttpRequest, upstream: Upstream): Future[HttpResponse] = {
+  def request(request: HttpRequest,
+              upstream: Upstream[AddressingConfig]): Future[HttpResponse] = {
     val targetedRequest =
-      upstream.addressRequestWithOverrides(request, localHostname)
+      upstream.addressRequestWithOverrides(request, addressingConfig)
 
     val proxyRequest =
       targetedRequest

--- a/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/ProxyController.scala
+++ b/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/ProxyController.scala
@@ -3,11 +3,11 @@ package com.pagerduty.akka.http.proxy
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 
-trait ProxyController {
+trait ProxyController[AddressingConfig] {
 
-  def httpProxy: HttpProxy
+  def httpProxy: HttpProxy[AddressingConfig]
 
-  def proxyRouteUnauthenticated[U <: Upstream](upstream: U): Route =
+  def proxyRouteUnauthenticated(upstream: Upstream[AddressingConfig]): Route =
     extractRequest { request =>
       complete {
         httpProxy.request(request, upstream)

--- a/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/Upstream.scala
+++ b/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/Upstream.scala
@@ -3,7 +3,7 @@ package com.pagerduty.akka.http.proxy
 import akka.http.scaladsl.model.{HttpRequest, Uri}
 import akka.http.scaladsl.model.Uri.Authority
 
-trait Upstream {
+trait Upstream[AddressingConfig] {
   def metricsTag: String
   def overrideEnvName: String = metricsTag.toUpperCase
 
@@ -19,9 +19,11 @@ trait Upstream {
     }
   }
 
-  def addressRequestWithOverrides(request: HttpRequest,
-                                  localHostname: String): HttpRequest = {
-    addressRequest(request).getOrElse(addressRequest(request, localHostname))
+  def addressRequestWithOverrides(
+      request: HttpRequest,
+      addressingConfig: AddressingConfig): HttpRequest = {
+    addressRequest(request).getOrElse(
+      addressRequest(request, addressingConfig))
   }
 
   private def addressRequest(request: HttpRequest): Option[HttpRequest] = {
@@ -31,7 +33,8 @@ trait Upstream {
     }
   }
 
-  def addressRequest(request: HttpRequest, localHostname: String): HttpRequest
+  def addressRequest(request: HttpRequest,
+                     addressingConfig: AddressingConfig): HttpRequest
 
   def addressRequestWithHostPort(request: HttpRequest,
                                  host: String,
@@ -43,11 +46,11 @@ trait Upstream {
   }
 }
 
-trait LocalPortUpstream extends Upstream {
-  def localPort: Int
+trait CommonHostnameUpstream extends Upstream[String] {
+  def port: Int
 
   def addressRequest(request: HttpRequest,
-                     localHostname: String): HttpRequest = {
-    addressRequestWithHostPort(request, localHostname, localPort)
+                     commonHostname: String): HttpRequest = {
+    addressRequestWithHostPort(request, commonHostname, port)
   }
 }

--- a/akka-http-proxy/src/test/scala/com/pagerduty/akka/http/proxy/CommonHostnameUpstreamSpec.scala
+++ b/akka-http-proxy/src/test/scala/com/pagerduty/akka/http/proxy/CommonHostnameUpstreamSpec.scala
@@ -4,21 +4,21 @@ import akka.http.scaladsl.model.{HttpRequest, Uri}
 import akka.http.scaladsl.model.Uri.Authority
 import org.scalatest.{FreeSpecLike, Matchers}
 
-class LocalPortUpstreamSpec extends FreeSpecLike with Matchers {
+class CommonHostnameUpstreamSpec extends FreeSpecLike with Matchers {
   "LocalPortUpstream" - {
     "targets a request to the upstreams local port" in {
       val request = HttpRequest()
       val localHostname = "some-local-host"
       val targetPort = 4567
-      val upstream = new LocalPortUpstream {
-        val localPort = targetPort
+      val upstream = new CommonHostnameUpstream {
+        val port = targetPort
         val metricsTag = "test"
       }
 
       val targetedReq = upstream.addressRequest(request, localHostname)
 
       val expectedAuthority =
-        Authority(Uri.Host(localHostname), upstream.localPort)
+        Authority(Uri.Host(localHostname), upstream.port)
       targetedReq.uri.authority should equal(expectedAuthority)
     }
   }

--- a/akka-http-proxy/src/test/scala/com/pagerduty/akka/http/proxy/HttpProxySpec.scala
+++ b/akka-http-proxy/src/test/scala/com/pagerduty/akka/http/proxy/HttpProxySpec.scala
@@ -12,8 +12,8 @@ import scala.concurrent.Future
 
 class HttpProxySpec extends FreeSpecLike with Matchers {
   "An HttpProxy" - {
-    val upstream = new LocalPortUpstream {
-      val localPort = 1234
+    val upstream = new CommonHostnameUpstream {
+      val port = 1234
       val metricsTag = "test"
     }
 

--- a/akka-http-proxy/src/test/scala/com/pagerduty/akka/http/proxy/ProxyControllerSpec.scala
+++ b/akka-http-proxy/src/test/scala/com/pagerduty/akka/http/proxy/ProxyControllerSpec.scala
@@ -1,11 +1,11 @@
 package com.pagerduty.akka.http.proxy
 
-import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FreeSpecLike, Matchers}
 
-import scala.concurrent.Promise
+import scala.concurrent.Future
 
 class ProxyControllerSpec
     extends FreeSpecLike
@@ -14,21 +14,22 @@ class ProxyControllerSpec
     with MockFactory { outer =>
 
   "ProxyControllerSpec" - {
-    val httpStub = stub[HttpProxy]
-    val c = new ProxyController {
+    val expectedResponse = HttpResponse(201)
+
+    val httpStub = new HttpProxy[String](null, null)(null, null, null) {
+      override def request(request: HttpRequest,
+                           upstream: Upstream[String]): Future[HttpResponse] =
+        Future.successful(expectedResponse)
+    }
+    val c = new ProxyController[String] {
       override def httpProxy = httpStub
     }
-    val upstream = new LocalPortUpstream {
-      val localPort = 123
+    val upstream = new CommonHostnameUpstream {
+      val port = 123
       val metricsTag = "test"
     }
 
     "proxies unauthenticated routes" in {
-      val expectedResponse = HttpResponse(201)
-      (c.httpProxy.request _)
-        .when(*, upstream)
-        .returns(Promise.successful(expectedResponse).future)
-
       Seq(Get(_: String),
           Post(_: String),
           Put(_: String),


### PR DESCRIPTION
Previously, the only runtime data that could be used to address a request to an `Upstream` was the `localHostname`. This was tightly coupled to the `LocalPortUpstream` and was of questionable use in other `Upstream`s. So, this PR generalizes that runtime data to be an arbitrary type named `AddressingConfig`.

`LocalPortUpstream` was poorly named as well. While the upstream could exist on the same host as the API gateway, there was no reason this had to be case since it already accepts an arbitrary hostname for addressing. This PR renames that class to `CommonHostnameUpstream` to reflect the fact that it uses a single hostname for all instances, provided at runtime.

Some unfortunate shenanigans in here with ScalaMock refusing to stub `HttpProxy[AddressingConfig]`. Manually generated stubs are used instead. ScalaMock is becoming increasingly less useful :-(.