### PR TITLE
Add X-Request-Id header to upstream aggregator requests.

### DIFF
--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/AggregatorUpstream.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/AggregatorUpstream.scala
@@ -3,6 +3,7 @@ package com.pagerduty.akka.http.aggregator
 import akka.http.scaladsl.model.HttpRequest
 import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
 import com.pagerduty.akka.http.proxy.Upstream
+import com.pagerduty.akka.http.support.RequestIdHeader
 
 trait AggregatorUpstream[AddressingConfig] extends Upstream[AddressingConfig] {
   def prepareAggregatorRequestForDelivery(
@@ -10,10 +11,16 @@ trait AggregatorUpstream[AddressingConfig] extends Upstream[AddressingConfig] {
       request: HttpRequest,
       modelRequest: HttpRequest
   ): HttpRequest = {
+    val reqWithMaybeIdHeader = modelRequest.header[RequestIdHeader] match {
+      case Some(h) => request.addHeader(h)
+      case None => request
+    }
+
     // we will always have an auth header by this point
     val authHeader = modelRequest.headers
       .find(_.is(authConfig.authHeaderName.toLowerCase))
       .get
-    request.addHeader(authHeader)
+
+    reqWithMaybeIdHeader.addHeader(authHeader)
   }
 }

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/AggregatorUpstreamSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/AggregatorUpstreamSpec.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.{HttpHeader, HttpRequest}
 import akka.http.scaladsl.model.headers._
 import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
 import com.pagerduty.akka.http.requestauthentication.model.AuthenticationData.AuthFailedReason
-import com.pagerduty.akka.http.support.RequestMetadata
+import com.pagerduty.akka.http.support.{RequestIdHeader, RequestMetadata}
 import org.scalatest.{FreeSpecLike, Matchers}
 
 import scala.concurrent.Future
@@ -47,7 +47,10 @@ class AggregatorUpstreamSpec extends FreeSpecLike with Matchers {
 
     "prepares an aggregator request for delivery" in {
       val request = HttpRequest()
-      val modelRequest = HttpRequest().addHeader(authHeader)
+      val requestId = "some-request-id"
+      val modelRequest = HttpRequest()
+        .addHeader(authHeader)
+        .addHeader(RequestIdHeader(requestId))
 
       val preparedReq =
         u.prepareAggregatorRequestForDelivery(ac, request, modelRequest)
@@ -55,6 +58,8 @@ class AggregatorUpstreamSpec extends FreeSpecLike with Matchers {
       preparedReq.headers
         .find(_.is(authHeader.lowercaseName))
         .get should equal(authHeader)
+
+      preparedReq.header[RequestIdHeader].get.value should equal(requestId)
     }
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.19.0"
+version in ThisBuild := "0.20.0"


### PR DESCRIPTION
The `X-Request-ID` header is added to the aggregator request only if present on the original incoming request. This should make aggregator request tracing easier.