### PR TITLE
Codify short-circuit aggregation

### DIFF
--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/AggregatorController.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/AggregatorController.scala
@@ -18,9 +18,9 @@ trait AggregatorController[AuthConfig <: HeaderAuthConfig, AddressingConfig] {
   implicit def executionContext: ExecutionContext
   implicit def materializer: Materializer
 
-  def prefixAggregatorRoute[RequestKey, AccumulatedState](
+  def prefixAggregatorRoute(
       pathMatcher: PathMatcher[Unit],
-      aggregator: Aggregator[RequestKey, AccumulatedState, AddressingConfig],
+      aggregator: Aggregator[AddressingConfig],
       requiredPermission: Option[AuthConfig#Permission] = None
   ): Route = {
     pathPrefix(pathMatcher) {
@@ -28,8 +28,8 @@ trait AggregatorController[AuthConfig <: HeaderAuthConfig, AddressingConfig] {
     }
   }
 
-  def aggregatorRoute[RequestKey, AccumulatedState](
-      aggregator: Aggregator[RequestKey, AccumulatedState, AddressingConfig],
+  def aggregatorRoute(
+      aggregator: Aggregator[AddressingConfig],
       requiredPermission: Option[AuthConfig#Permission] = None
   ): Route = {
     extractRequest { incomingRequest =>

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/AggregatorController.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/AggregatorController.scala
@@ -1,9 +1,7 @@
 package com.pagerduty.akka.http.aggregator
 
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{PathMatcher, Route}
-import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
 import com.pagerduty.akka.http.headerauthentication.HeaderAuthenticator
 import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
@@ -11,12 +9,12 @@ import com.pagerduty.akka.http.aggregator.aggregator.Aggregator
 import com.pagerduty.akka.http.proxy.HttpProxy
 import com.pagerduty.akka.http.support.RequestMetadata
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 trait AggregatorController[AuthConfig <: HeaderAuthConfig, AddressingConfig] {
   val authConfig: AuthConfig
-  def httpProxy: HttpProxy[AddressingConfig]
   def headerAuthenticator: HeaderAuthenticator
+  implicit def httpProxy: HttpProxy[AddressingConfig]
   implicit def executionContext: ExecutionContext
   implicit def materializer: Materializer
 
@@ -43,73 +41,9 @@ trait AggregatorController[AuthConfig <: HeaderAuthConfig, AddressingConfig] {
           false,
           requiredPermission.asInstanceOf[Option[authConfig.Permission]]
         ) { (authedRequest, authData) =>
-          // get the initial upstream requests from the aggregator, along with any saved state
-          val (initialState, initialRequests) =
-            aggregator.handleIncomingRequest(authConfig)(incomingRequest,
-                                                         authData)
-
-          // execute those initial upstream requests
-          val futureInitialResponses = executeRequests(authConfig,
-                                                       initialState,
-                                                       initialRequests,
-                                                       authedRequest)
-
-          // we have the initial upstream responses, pass them into the first handler, and iterate through the subsequent handlers
-          val finalStateAndResponseMap =
-            aggregator.intermediateResponseHandlers.foldLeft(
-              futureInitialResponses) { (futureStateAndResponses, builder) =>
-              futureStateAndResponses.flatMap {
-                case (previousState, responseMap) =>
-                  // we have the responses, pass them to the next handler along with the previous state
-                  val (newState, requests) =
-                    builder(previousState, responseMap)
-
-                  // execute the next stage of requests returned from the handler
-                  executeRequests(authConfig,
-                                  newState,
-                                  requests,
-                                  authedRequest)
-              }
-            }
-
-          // all the intermediate handlers have run, tell the aggregator to build the outgoing response
-          finalStateAndResponseMap.map {
-            case (finalState, responseMap) =>
-              aggregator.buildOutgoingResponse(finalState, responseMap)
-          }
+          aggregator.execute(authConfig)(authedRequest, authData)
         }
       }
     }
-  }
-
-  private def executeRequests[RequestKey, AccumulatedState](
-      authConfig: HeaderAuthConfig,
-      state: AccumulatedState,
-      requests: Map[RequestKey,
-                    (AggregatorUpstream[AddressingConfig], HttpRequest)],
-      authedRequest: HttpRequest
-  ): Future[(AccumulatedState, Map[RequestKey, (HttpResponse, String)])] = {
-    val preparedRequests = requests.map {
-      case (key, (upstream, req)) =>
-        val preppedReq =
-          upstream.prepareAggregatorRequestForDelivery(authConfig,
-                                                       req,
-                                                       authedRequest)
-        (key, (upstream, preppedReq))
-    }
-
-    Future
-      .sequence(preparedRequests.map {
-        case (key, (upstream, r)) =>
-          httpProxy
-            .request(r, upstream)
-            .flatMap(resp => {
-              Unmarshal(resp.entity)
-                .to[String]
-                .map(entity => (key, (resp, entity)))
-            })
-      }.toSeq)
-      .map(_.toMap)
-      .map(responseMap => (state, responseMap))
   }
 }

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/Aggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/Aggregator.scala
@@ -1,133 +1,17 @@
 package com.pagerduty.akka.http.aggregator.aggregator
 
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
-import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
-import com.pagerduty.akka.http.aggregator.AggregatorUpstream
 import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
 import com.pagerduty.akka.http.proxy.HttpProxy
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait Aggregator[RequestKey, AccumulatedState, AddressingConfig] {
-  type RequestMap =
-    Map[RequestKey, (AggregatorUpstream[AddressingConfig], HttpRequest)]
-  type ResponseMap = Map[RequestKey, (HttpResponse, String)]
-  type HandlerInput = (AccumulatedState, ResponseMap)
-  type AccumulatedStateAndRequests = (AccumulatedState, RequestMap)
-  type HandlerResult = Either[HttpResponse, AccumulatedStateAndRequests]
-  type ResponseHandler = HandlerInput => HandlerResult
-
-  // implement these methods
-  def handleIncomingRequest(
-      authConfig: HeaderAuthConfig
-  )(incomingRequest: HttpRequest, authData: authConfig.AuthData): HandlerResult
-
-  def intermediateResponseHandlers: Seq[ResponseHandler]
-
-  def buildOutgoingResponse(accumulatedState: AccumulatedState,
-                            upstreamResponses: ResponseMap): HttpResponse
-
-  // implementation
+trait Aggregator[AddressingConfig] {
   def execute(authConfig: HeaderAuthConfig)(authedRequest: HttpRequest,
                                             authData: authConfig.AuthData)(
       implicit httpProxy: HttpProxy[AddressingConfig],
       executionContext: ExecutionContext,
-      materializer: Materializer): Future[HttpResponse] = {
-    val initialHandlerResult =
-      handleIncomingRequest(authConfig)(authedRequest, authData)
+      materializer: Materializer): Future[HttpResponse]
 
-    initialHandlerResult match {
-      case Right((initialState, initialRequests)) =>
-        // the initial handler returned some requests, execute them
-        val fInitialResponses = executeRequests(authConfig)(initialState,
-                                                            initialRequests,
-                                                            authedRequest)
-
-        val intermediateHandlersResult = executeIntermediateHandlers(
-          authConfig)(authedRequest, fInitialResponses)
-
-        // all the intermediate handlers have run (or short-circuited), tell the aggregator to build the outgoing response
-        intermediateHandlersResult.map {
-          case Right((finalState, responseMap)) =>
-            // we don't have a response yet, have the aggregator do the final response build
-            buildOutgoingResponse(finalState, responseMap)
-          case Left(shortCircuit) =>
-            // we already have the final (short-circuit) response
-            shortCircuit
-        }
-      case Left(httpResponse) =>
-        // the initial handler short-circuited and provided a response from the initial request, don't run intermediate handlers or final builder
-        Future.successful(httpResponse)
-    }
-  }
-
-  private def executeIntermediateHandlers(authConfig: HeaderAuthConfig)(
-      authedRequest: HttpRequest,
-      fInitialStateAndResponses: Future[(AccumulatedState, ResponseMap)])(
-      implicit httpProxy: HttpProxy[AddressingConfig],
-      executionContext: ExecutionContext,
-      materializer: Materializer)
-    : Future[Either[HttpResponse, (AccumulatedState, ResponseMap)]] = {
-    val fFirstIntermediateHandlerInput
-      : Future[Either[HttpResponse, HandlerInput]] =
-      fInitialStateAndResponses.map { initialStateAndResponses =>
-        Right(initialStateAndResponses)
-      }
-
-    // we have the initial handler input; pass it into the first handler, and iterate through the subsequent handlers
-    intermediateResponseHandlers.foldLeft(fFirstIntermediateHandlerInput) {
-      (fRespOrStateAndResponses, handler) =>
-        fRespOrStateAndResponses.flatMap {
-          case Right((previousState, responseMap)) =>
-            // we have state and responses, so we pass them to this handler
-            val respOrNewRequestMap = handler(previousState, responseMap)
-
-            respOrNewRequestMap match {
-              case Right((newState, requests)) =>
-                // the handler returned some requests, execute them
-                executeRequests(authConfig)(newState, requests, authedRequest)
-                  .map(responses => Right(responses))
-              case Left(sc) =>
-                // the handler returned a short-circuit response, wrap it
-                Future.successful(Left(sc))
-            }
-          case shortCircuit @ Left(_) =>
-            // we have a short-circuit response, don't execute this handler
-            Future.successful(shortCircuit)
-        }
-    }
-  }
-
-  private def executeRequests[RequestKey, AccumulatedState](
-      authConfig: HeaderAuthConfig)(
-      state: AccumulatedState,
-      requests: RequestMap,
-      authedRequest: HttpRequest
-  )(implicit httpProxy: HttpProxy[AddressingConfig],
-    executionContext: ExecutionContext,
-    materializer: Materializer): Future[(AccumulatedState, ResponseMap)] = {
-    val preparedRequests = requests.map {
-      case (key, (upstream, req)) =>
-        val preppedReq =
-          upstream.prepareAggregatorRequestForDelivery(authConfig,
-                                                       req,
-                                                       authedRequest)
-        (key, (upstream, preppedReq))
-    }
-
-    Future
-      .sequence(preparedRequests.map {
-        case (key, (upstream, r)) =>
-          httpProxy
-            .request(r, upstream)
-            .flatMap(resp => {
-              Unmarshal(resp.entity)
-                .to[String]
-                .map(entity => (key, (resp, entity)))
-            })
-      }.toSeq)
-      .map(_.toMap)
-      .map(responseMap => (state, responseMap))
-  }
 }

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/Aggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/Aggregator.scala
@@ -1,23 +1,133 @@
 package com.pagerduty.akka.http.aggregator.aggregator
 
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.Materializer
 import com.pagerduty.akka.http.aggregator.AggregatorUpstream
-import com.pagerduty.akka.http.requestauthentication.model.AuthenticationConfig
+import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
+import com.pagerduty.akka.http.proxy.HttpProxy
+
+import scala.concurrent.{ExecutionContext, Future}
 
 trait Aggregator[RequestKey, AccumulatedState, AddressingConfig] {
   type RequestMap =
     Map[RequestKey, (AggregatorUpstream[AddressingConfig], HttpRequest)]
   type ResponseMap = Map[RequestKey, (HttpResponse, String)]
-  type ResponseHandler =
-    (AccumulatedState, ResponseMap) => (AccumulatedState, RequestMap)
+  type HandlerInput = (AccumulatedState, ResponseMap)
+  type AccumulatedStateAndRequests = (AccumulatedState, RequestMap)
+  type HandlerResult = Either[HttpResponse, AccumulatedStateAndRequests]
+  type ResponseHandler = HandlerInput => HandlerResult
 
+  // implement these methods
   def handleIncomingRequest(
-      authConfig: AuthenticationConfig
-  )(incomingRequest: HttpRequest,
-    authData: authConfig.AuthData): (AccumulatedState, RequestMap)
+      authConfig: HeaderAuthConfig
+  )(incomingRequest: HttpRequest, authData: authConfig.AuthData): HandlerResult
 
   def intermediateResponseHandlers: Seq[ResponseHandler]
 
   def buildOutgoingResponse(accumulatedState: AccumulatedState,
                             upstreamResponses: ResponseMap): HttpResponse
+
+  // implementation
+  def execute(authConfig: HeaderAuthConfig)(authedRequest: HttpRequest,
+                                            authData: authConfig.AuthData)(
+      implicit httpProxy: HttpProxy[AddressingConfig],
+      executionContext: ExecutionContext,
+      materializer: Materializer): Future[HttpResponse] = {
+    val initialHandlerResult =
+      handleIncomingRequest(authConfig)(authedRequest, authData)
+
+    initialHandlerResult match {
+      case Right((initialState, initialRequests)) =>
+        // the initial handler returned some requests, execute them
+        val fInitialResponses = executeRequests(authConfig)(initialState,
+                                                            initialRequests,
+                                                            authedRequest)
+
+        val intermediateHandlersResult = executeIntermediateHandlers(
+          authConfig)(authedRequest, fInitialResponses)
+
+        // all the intermediate handlers have run (or short-circuited), tell the aggregator to build the outgoing response
+        intermediateHandlersResult.map {
+          case Right((finalState, responseMap)) =>
+            // we don't have a response yet, have the aggregator do the final response build
+            buildOutgoingResponse(finalState, responseMap)
+          case Left(shortCircuit) =>
+            // we already have the final (short-circuit) response
+            shortCircuit
+        }
+      case Left(httpResponse) =>
+        // the initial handler short-circuited and provided a response from the initial request, don't run intermediate handlers or final builder
+        Future.successful(httpResponse)
+    }
+  }
+
+  private def executeIntermediateHandlers(authConfig: HeaderAuthConfig)(
+      authedRequest: HttpRequest,
+      fInitialStateAndResponses: Future[(AccumulatedState, ResponseMap)])(
+      implicit httpProxy: HttpProxy[AddressingConfig],
+      executionContext: ExecutionContext,
+      materializer: Materializer)
+    : Future[Either[HttpResponse, (AccumulatedState, ResponseMap)]] = {
+    val fFirstIntermediateHandlerInput
+      : Future[Either[HttpResponse, HandlerInput]] =
+      fInitialStateAndResponses.map { initialStateAndResponses =>
+        Right(initialStateAndResponses)
+      }
+
+    // we have the initial handler input; pass it into the first handler, and iterate through the subsequent handlers
+    intermediateResponseHandlers.foldLeft(fFirstIntermediateHandlerInput) {
+      (fRespOrStateAndResponses, handler) =>
+        fRespOrStateAndResponses.flatMap {
+          case Right((previousState, responseMap)) =>
+            // we have state and responses, so we pass them to this handler
+            val respOrNewRequestMap = handler(previousState, responseMap)
+
+            respOrNewRequestMap match {
+              case Right((newState, requests)) =>
+                // the handler returned some requests, execute them
+                executeRequests(authConfig)(newState, requests, authedRequest)
+                  .map(responses => Right(responses))
+              case Left(sc) =>
+                // the handler returned a short-circuit response, wrap it
+                Future.successful(Left(sc))
+            }
+          case shortCircuit @ Left(_) =>
+            // we have a short-circuit response, don't execute this handler
+            Future.successful(shortCircuit)
+        }
+    }
+  }
+
+  private def executeRequests[RequestKey, AccumulatedState](
+      authConfig: HeaderAuthConfig)(
+      state: AccumulatedState,
+      requests: RequestMap,
+      authedRequest: HttpRequest
+  )(implicit httpProxy: HttpProxy[AddressingConfig],
+    executionContext: ExecutionContext,
+    materializer: Materializer): Future[(AccumulatedState, ResponseMap)] = {
+    val preparedRequests = requests.map {
+      case (key, (upstream, req)) =>
+        val preppedReq =
+          upstream.prepareAggregatorRequestForDelivery(authConfig,
+                                                       req,
+                                                       authedRequest)
+        (key, (upstream, preppedReq))
+    }
+
+    Future
+      .sequence(preparedRequests.map {
+        case (key, (upstream, r)) =>
+          httpProxy
+            .request(r, upstream)
+            .flatMap(resp => {
+              Unmarshal(resp.entity)
+                .to[String]
+                .map(entity => (key, (resp, entity)))
+            })
+      }.toSeq)
+      .map(_.toMap)
+      .map(responseMap => (state, responseMap))
+  }
 }

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/GenericAggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/GenericAggregator.scala
@@ -1,0 +1,133 @@
+package com.pagerduty.akka.http.aggregator.aggregator
+
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.Materializer
+import com.pagerduty.akka.http.aggregator.AggregatorUpstream
+import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
+import com.pagerduty.akka.http.proxy.HttpProxy
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait GenericAggregator[RequestKey, AccumulatedState, AddressingConfig]
+    extends Aggregator[AddressingConfig] {
+  type RequestMap =
+    Map[RequestKey, (AggregatorUpstream[AddressingConfig], HttpRequest)]
+  type ResponseMap = Map[RequestKey, (HttpResponse, String)]
+  type AccumulatedStateAndRequests = (AccumulatedState, RequestMap)
+  type HandlerResult = Either[HttpResponse, AccumulatedStateAndRequests]
+  type ResponseHandler = (AccumulatedState, ResponseMap) => HandlerResult
+
+  // implement these methods
+  def handleIncomingRequest(
+      authConfig: HeaderAuthConfig
+  )(incomingRequest: HttpRequest, authData: authConfig.AuthData): HandlerResult
+
+  def intermediateResponseHandlers: Seq[ResponseHandler]
+
+  def buildOutgoingResponse(accumulatedState: AccumulatedState,
+                            upstreamResponses: ResponseMap): HttpResponse
+
+  // implementation
+  def execute(authConfig: HeaderAuthConfig)(authedRequest: HttpRequest,
+                                            authData: authConfig.AuthData)(
+      implicit httpProxy: HttpProxy[AddressingConfig],
+      executionContext: ExecutionContext,
+      materializer: Materializer): Future[HttpResponse] = {
+    val initialHandlerResult =
+      handleIncomingRequest(authConfig)(authedRequest, authData)
+
+    initialHandlerResult match {
+      case Right((initialState, initialRequests)) =>
+        // the initial handler returned some requests, execute them
+        val fInitialResponses = executeRequests(authConfig)(initialState,
+                                                            initialRequests,
+                                                            authedRequest)
+
+        val intermediateHandlersResult = executeIntermediateHandlers(
+          authConfig)(authedRequest, fInitialResponses)
+
+        // all the intermediate handlers have run (or short-circuited), tell the aggregator to build the outgoing response
+        intermediateHandlersResult.map {
+          case Right((finalState, responseMap)) =>
+            // we don't have a response yet, have the aggregator do the final response build
+            buildOutgoingResponse(finalState, responseMap)
+          case Left(shortCircuit) =>
+            // we already have the final (short-circuit) response
+            shortCircuit
+        }
+      case Left(httpResponse) =>
+        // the initial handler short-circuited and provided a response from the initial request, don't run intermediate handlers or final builder
+        Future.successful(httpResponse)
+    }
+  }
+
+  private def executeIntermediateHandlers(authConfig: HeaderAuthConfig)(
+      authedRequest: HttpRequest,
+      fInitialStateAndResponses: Future[(AccumulatedState, ResponseMap)])(
+      implicit httpProxy: HttpProxy[AddressingConfig],
+      executionContext: ExecutionContext,
+      materializer: Materializer)
+    : Future[Either[HttpResponse, (AccumulatedState, ResponseMap)]] = {
+    val fFirstIntermediateHandlerInput
+      : Future[Either[HttpResponse, (AccumulatedState, ResponseMap)]] =
+      fInitialStateAndResponses.map { initialStateAndResponses =>
+        Right(initialStateAndResponses)
+      }
+
+    // we have the initial handler input; pass it into the first handler, and iterate through the subsequent handlers
+    intermediateResponseHandlers.foldLeft(fFirstIntermediateHandlerInput) {
+      (fRespOrStateAndResponses, handler) =>
+        fRespOrStateAndResponses.flatMap {
+          case Right((previousState, responseMap)) =>
+            // we have state and responses, so we pass them to this handler
+            val respOrNewRequestMap = handler(previousState, responseMap)
+
+            respOrNewRequestMap match {
+              case Right((newState, requests)) =>
+                // the handler returned some requests, execute them
+                executeRequests(authConfig)(newState, requests, authedRequest)
+                  .map(responses => Right(responses))
+              case Left(sc) =>
+                // the handler returned a short-circuit response, wrap it
+                Future.successful(Left(sc))
+            }
+          case shortCircuit @ Left(_) =>
+            // we have a short-circuit response, don't execute this handler
+            Future.successful(shortCircuit)
+        }
+    }
+  }
+
+  private def executeRequests[RequestKey, AccumulatedState](
+      authConfig: HeaderAuthConfig)(
+      state: AccumulatedState,
+      requests: RequestMap,
+      authedRequest: HttpRequest
+  )(implicit httpProxy: HttpProxy[AddressingConfig],
+    executionContext: ExecutionContext,
+    materializer: Materializer): Future[(AccumulatedState, ResponseMap)] = {
+    val preparedRequests = requests.map {
+      case (key, (upstream, req)) =>
+        val preppedReq =
+          upstream.prepareAggregatorRequestForDelivery(authConfig,
+                                                       req,
+                                                       authedRequest)
+        (key, (upstream, preppedReq))
+    }
+
+    Future
+      .sequence(preparedRequests.map {
+        case (key, (upstream, r)) =>
+          httpProxy
+            .request(r, upstream)
+            .flatMap(resp => {
+              Unmarshal(resp.entity)
+                .to[String]
+                .map(entity => (key, (resp, entity)))
+            })
+      }.toSeq)
+      .map(_.toMap)
+      .map(responseMap => (state, responseMap))
+  }
+}

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepAggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepAggregator.scala
@@ -5,11 +5,7 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import com.pagerduty.akka.http.requestauthentication.model.AuthenticationConfig
 
 trait OneStepAggregator[RequestKey, AddressingConfig]
-    extends Aggregator[RequestKey, NotUsed, AddressingConfig] {
-  def handleIncomingRequest(
-      authConfig: AuthenticationConfig
-  )(incomingRequest: HttpRequest,
-    authData: authConfig.AuthData): (NotUsed, RequestMap)
+    extends GenericAggregator[RequestKey, NotUsed, AddressingConfig] {
 
   def intermediateResponseHandlers: Seq[ResponseHandler] = Seq()
 

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepAggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepAggregator.scala
@@ -4,9 +4,8 @@ trait TwoStepAggregator[RequestKey, AccumulatedState, AddressingConfig]
     extends Aggregator[RequestKey, AccumulatedState, AddressingConfig] {
 
   def handleUpstreamResponses(
-      initialState: AccumulatedState,
-      upstreamResponseMap: ResponseMap
-  ): (AccumulatedState, RequestMap)
+      handlerInput: HandlerInput
+  ): HandlerResult
 
   def intermediateResponseHandlers: Seq[ResponseHandler] =
     Seq(handleUpstreamResponses)

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepAggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepAggregator.scala
@@ -1,11 +1,10 @@
 package com.pagerduty.akka.http.aggregator.aggregator
 
 trait TwoStepAggregator[RequestKey, AccumulatedState, AddressingConfig]
-    extends Aggregator[RequestKey, AccumulatedState, AddressingConfig] {
+    extends GenericAggregator[RequestKey, AccumulatedState, AddressingConfig] {
 
-  def handleUpstreamResponses(
-      handlerInput: HandlerInput
-  ): HandlerResult
+  def handleUpstreamResponses(initialState: AccumulatedState,
+                              upstreamResponseMap: ResponseMap): HandlerResult
 
   def intermediateResponseHandlers: Seq[ResponseHandler] =
     Seq(handleUpstreamResponses)

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/AggregatorControllerSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/AggregatorControllerSpec.scala
@@ -1,32 +1,20 @@
 package com.pagerduty.akka.http.aggregator
 
 import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import akka.stream.ActorMaterializer
+import akka.stream.{ActorMaterializer, Materializer}
 import com.pagerduty.akka.http.headerauthentication.HeaderAuthenticator
 import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
-import com.pagerduty.akka.http.aggregator.aggregator.{
-  Aggregator,
-  OneStepJsonHydrationAggregator,
-  TwoStepJsonHydrationAggregator
-}
-import com.pagerduty.akka.http.proxy.{
-  CommonHostnameUpstream,
-  HttpProxy,
-  Upstream
-}
+import com.pagerduty.akka.http.aggregator.aggregator.Aggregator
+import com.pagerduty.akka.http.aggregator.support.TestAuthConfig
+import com.pagerduty.akka.http.proxy.HttpProxy
 import com.pagerduty.akka.http.requestauthentication.RequestAuthenticator
-import com.pagerduty.akka.http.requestauthentication.model.AuthenticationConfig
-import com.pagerduty.akka.http.requestauthentication.model.AuthenticationData.AuthFailedReason
 import com.pagerduty.akka.http.support.RequestMetadata
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FreeSpecLike, Matchers}
-import ujson.Js
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
 
 class AggregatorControllerSpec
     extends FreeSpecLike
@@ -34,48 +22,10 @@ class AggregatorControllerSpec
     with MockFactory
     with ScalatestRouteTest {
 
-  class TestAuthConfig extends HeaderAuthConfig {
-    type Cred = String
-    type AuthData = String
-    type Permission = String
-    type AuthHeader = RawHeader
-
-    def extractCredentials(request: HttpRequest)(
-        implicit reqMeta: RequestMetadata): List[Cred] = ???
-
-    def authenticate(credential: Cred)(
-        implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]] = ???
-
-    def authDataGrantsPermission(
-        authData: AuthData,
-        request: HttpRequest,
-        permission: Option[Permission]
-    )(implicit reqMeta: RequestMetadata): Option[AuthFailedReason] = ???
-
-    def dataToAuthHeader(data: AuthData)(
-        implicit reqMeta: RequestMetadata): AuthHeader = ???
-    def authHeaderName: String = ???
-  }
-
-  case class TestUpstream(port: Int, metricsTag: String)
-      extends CommonHostnameUpstream
-      with AggregatorUpstream[String] {
-    override def prepareAggregatorRequestForDelivery(
-        authConfig: HeaderAuthConfig,
-        request: HttpRequest,
-        modelRequest: HttpRequest
-    ): HttpRequest =
-      request
-  }
-
   "AggregatorController" - {
     val ac = new TestAuthConfig
-
-    val expectedAuthData = "auth-data"
-    val upstream1 = TestUpstream(1, "1")
-    val upstream2 = TestUpstream(2, "2")
-
-    val authToken = "auth-token"
+    val testAuthData = "test-auth-data"
+    val expectedResponse = HttpResponse(StatusCodes.NotModified)
 
     def buildController(stubHttpProxy: HttpProxy[String] = null)
       : AggregatorController[TestAuthConfig, String] = {
@@ -96,8 +46,7 @@ class AggregatorControllerSpec
             if (request.uri.path.toString.contains("failed-auth")) {
               Future.successful(HttpResponse(Unauthorized))
             } else {
-              handler(request,
-                      expectedAuthData.asInstanceOf[authConfig.AuthData])
+              handler(request, testAuthData.asInstanceOf[authConfig.AuthData])
             }
           }
         }
@@ -109,70 +58,23 @@ class AggregatorControllerSpec
       c
     }
 
-    "with a SimpleOneStepAggregator" - {
-      val request1 = HttpRequest(uri = "/req1")
-      val request2 = HttpRequest(uri = "/req2")
+    "with a simple test Aggregator" - {
 
-      val entity1 = "{ \"entity\": 1 }"
-      val entity2 = "{ \"entity\": 2 }"
-
-      val entityJson1 = ujson.read(entity1)
-      val entityJson2 = ujson.read(entity2)
-
-      val response1 = HttpResponse(entity = entity1)
-      val response2 = HttpResponse(entity = entity2)
-
-      val reqKey1 = "req1"
-      val reqKey2 = "req2"
-
-      val expectedRequests
-        : Map[String, (AggregatorUpstream[String], HttpRequest)] =
-        Map(reqKey1 -> (upstream1, request1), reqKey2 -> (upstream2, request2))
-      val expectedResponse = HttpResponse(entity = "aggregated data")
-
-      val expectedResponses = Map(reqKey1 -> (response1, entityJson1),
-                                  reqKey2 -> (response2, entityJson2))
-
-      class TestOneStepJsonHydrationAggregator
-          extends OneStepJsonHydrationAggregator[String] {
-        def handleIncomingRequestStateless(
-            authConfig: AuthenticationConfig
-        )(incomingRequest: HttpRequest, authData: authConfig.AuthData)
-          : Map[String, (AggregatorUpstream[String], HttpRequest)] = {
-          authData should equal(expectedAuthData)
-          expectedRequests
-        }
-
-        def buildOutgoingJsonResponseStateless(
-            upstreamResponses: Map[String, (HttpResponse, Js.Value)]
-        ): HttpResponse = {
-          upstreamResponses should equal(expectedResponses)
-          expectedResponse
+      class TestAggregator extends Aggregator[String] {
+        def execute(authConfig: HeaderAuthConfig)(
+            authedRequest: HttpRequest,
+            authData: authConfig.AuthData)(
+            implicit httpProxy: HttpProxy[String],
+            executionContext: ExecutionContext,
+            materializer: Materializer): Future[HttpResponse] = {
+          authData should equal(testAuthData)
+          Future.successful(expectedResponse)
         }
       }
 
-      val aggregator = new TestOneStepJsonHydrationAggregator
+      val aggregator = new TestAggregator
 
-      "sends requests to upstreams and aggregates the responses when auth succeeds" in {
-        val stubProxy = new HttpProxy[String](null, null)(null, null, null) {
-          override def request(
-              request: HttpRequest,
-              upstream: Upstream[String]): Future[HttpResponse] = {
-            upstream match {
-              case `upstream1` => Future.successful(response1)
-              case `upstream2` => Future.successful(response2)
-            }
-          }
-        }
-        val c = buildController(stubProxy)
-
-        Get("/") ~> c.prefixAggregatorRoute("", aggregator) ~> check {
-          handled shouldBe true
-          response should equal(expectedResponse)
-        }
-      }
-
-      "does not send requests to upstreams and returns Unauthorized when auth fails" in {
+      "does not execute the aggregator and returns Unauthorized when auth fails" in {
         val c = buildController()
         Get("/failed-auth") ~> c.prefixAggregatorRoute("failed-auth",
                                                        aggregator) ~> check {
@@ -185,176 +87,6 @@ class AggregatorControllerSpec
         val c = buildController()
         Get("/wrong-path") ~> c.prefixAggregatorRoute("aggregator", aggregator) ~> check {
           handled shouldBe false
-        }
-      }
-
-      "fails whole request when one request fails" in {
-        val stubProxy = new HttpProxy[String](null, null)(null, null, null) {
-          override def request(
-              request: HttpRequest,
-              upstream: Upstream[String]): Future[HttpResponse] = {
-            upstream match {
-              case `upstream1` => Future.successful(response1)
-              case `upstream2` =>
-                Future.failed(new RuntimeException("simulated exception"))
-            }
-          }
-        }
-        val c = buildController(stubProxy)
-
-        Get("/fail-path") ~> c.prefixAggregatorRoute("fail-path", aggregator) ~> check {
-          handled shouldBe true
-          response.status should equal(InternalServerError)
-        }
-      }
-    }
-
-    "with a TwoStepJsonHydrationAggregator" - {
-      val request1Key = "request1"
-      val request1 = HttpRequest(uri = "/req1")
-      val request2Key = "request2"
-      val request2 = HttpRequest(uri = "/req2")
-
-      val entity1 = "{ \"entity\": 1 }"
-      val entity2 = "{ \"entity\": 2 }"
-
-      val entityJson1 = ujson.read(entity1)
-      val entityJson2 = ujson.read(entity2)
-
-      val response1 = HttpResponse(entity = entity1)
-      val response2 = HttpResponse(entity = entity2)
-
-      val expectedRequests1 = Map(request1Key -> (upstream1, request1))
-      val expectedResponseMap1 = Map(request1Key -> (response1, entity1))
-
-      val expectedRequests2 = Map(request2Key -> (upstream2, request2))
-      val expectedResponseMap2 = Map(request2Key -> (response2, entity2))
-
-      val expectedResponse = HttpResponse(entity = "aggregated data")
-
-      val initialState = "initial"
-      val intermediateState = "intermediate"
-
-      class TestAggregator extends TwoStepJsonHydrationAggregator[String] {
-        def handleIncomingRequest(incomingRequest: HttpRequest)
-          : (AggregatorUpstream[String], HttpRequest) =
-          (upstream1, request1)
-
-        def handleJsonUpstreamResponse(upstreamResponse: HttpResponse,
-                                       upstreamJson: Js.Value): RequestMap = {
-          upstreamResponse should equal(response1)
-          upstreamJson should equal(entityJson1)
-
-          expectedRequests2
-        }
-
-        def buildOutgoingJsonResponse(
-            initialUpstreamJson: Js.Value,
-            upstreamResponseMap: Map[String, (HttpResponse, Js.Value)]
-        ): HttpResponse = {
-          initialUpstreamJson should equal(entityJson1)
-          upstreamResponseMap should have size (1)
-          upstreamResponseMap(request2Key) should equal(
-            (response2, entityJson2))
-
-          expectedResponse
-        }
-      }
-
-      val aggregator = new TestAggregator
-
-      "sends requests to upstreams and aggregates responses in multiple steps when auth succeeds" in {
-        val stubProxy = new HttpProxy[String](null, null)(null, null, null) {
-          override def request(
-              request: HttpRequest,
-              upstream: Upstream[String]): Future[HttpResponse] = {
-            upstream match {
-              case `upstream1` => Future.successful(response1)
-              case `upstream2` => Future.successful(response2)
-            }
-          }
-        }
-        val c = buildController(stubProxy)
-
-        Get("/") ~> c.prefixAggregatorRoute("", aggregator) ~> check {
-          handled shouldBe true
-          response should equal(expectedResponse)
-        }
-      }
-    }
-
-    "with an Aggregator" - {
-      val request1Key = "request1"
-      val request1 = HttpRequest(uri = "/req1")
-      val request2Key = "request2"
-      val request2 = HttpRequest(uri = "/req2")
-
-      val entity1 = "resp1"
-      val entity2 = "resp2"
-
-      val response1 = HttpResponse(entity = entity1)
-      val response2 = HttpResponse(entity = entity2)
-
-      val expectedRequests1 = Map(request1Key -> (upstream1, request1))
-      val expectedResponseMap1 = Map(request1Key -> (response1, entity1))
-
-      val expectedRequests2 = Map(request2Key -> (upstream2, request2))
-      val expectedResponseMap2 = Map(request2Key -> (response2, entity2))
-
-      val expectedResponse = HttpResponse(entity = "aggregated data")
-
-      val initialState = "initial"
-      val intermediateState = "intermediate"
-
-      class TestAggregator extends Aggregator[String, String, String] {
-        def handleIncomingRequest(
-            authConfig: AuthenticationConfig
-        )(incomingRequest: HttpRequest,
-          authData: authConfig.AuthData): (String, RequestMap) = {
-          authData should equal(expectedAuthData)
-          (initialState, expectedRequests1)
-        }
-
-        def handleIntermediateResponse(
-            state: String,
-            responses: ResponseMap): (String, RequestMap) = {
-          state should equal(initialState)
-          responses should equal(expectedResponseMap1)
-
-          (intermediateState, expectedRequests2)
-        }
-
-        def intermediateResponseHandlers: Seq[ResponseHandler] =
-          Seq(handleIntermediateResponse)
-
-        def buildOutgoingResponse(
-            state: String,
-            upstreamResponses: ResponseMap): HttpResponse = {
-          state should equal(intermediateState)
-          upstreamResponses should equal(expectedResponseMap2)
-
-          expectedResponse
-        }
-      }
-
-      val aggregator = new TestAggregator
-
-      "sends requests to upstreams and aggregates responses in multiple steps when auth succeeds" in {
-        val stubProxy = new HttpProxy[String](null, null)(null, null, null) {
-          override def request(
-              request: HttpRequest,
-              upstream: Upstream[String]): Future[HttpResponse] = {
-            upstream match {
-              case `upstream1` => Future.successful(response1)
-              case `upstream2` => Future.successful(response2)
-            }
-          }
-        }
-        val c = buildController(stubProxy)
-
-        Get("/") ~> c.prefixAggregatorRoute("", aggregator) ~> check {
-          handled shouldBe true
-          response should equal(expectedResponse)
         }
       }
     }

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/GenericAggregatorSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/GenericAggregatorSpec.scala
@@ -88,10 +88,8 @@ class GenericAggregatorSpec
         state should equal(initialState)
 
         if (responses == expectedResponseMap1) {
-          println("here")
           Right((intermediateState, expectedRequests2))
         } else {
-          println("there")
           Left(intermediateFailureResponse)
         }
       }

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/GenericAggregatorSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/GenericAggregatorSpec.scala
@@ -1,0 +1,115 @@
+package com.pagerduty.akka.http.aggregator.aggregator
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
+import com.pagerduty.akka.http.aggregator.support.{
+  TestAuthConfig,
+  TestUpstream
+}
+import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
+import com.pagerduty.akka.http.proxy.{HttpProxy, Upstream}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+class GenericAggregatorSpec
+    extends TestKit(ActorSystem("AggregatorSpec"))
+    with FreeSpecLike
+    with Matchers
+    with MockFactory
+    with BeforeAndAfterAll {
+
+  override def afterAll {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  implicit val executionContext = ExecutionContext.global
+  implicit val materializer = ActorMaterializer()
+
+  val ac = new TestAuthConfig
+
+  val testAuthData = "auth-data"
+
+  val upstream1 = TestUpstream(1, "1")
+  val upstream2 = TestUpstream(2, "2")
+
+  "A GenericAggregator" - {
+    val request1Key = "request1"
+    val request1 = HttpRequest(uri = "/req1")
+    val request2Key = "request2"
+    val request2 = HttpRequest(uri = "/req2")
+
+    val entity1 = "resp1"
+    val entity2 = "resp2"
+
+    val response1 = HttpResponse(entity = entity1)
+    val response2 = HttpResponse(entity = entity2)
+
+    val expectedRequests1 = Map(request1Key -> (upstream1, request1))
+    val expectedResponseMap1 = Map(request1Key -> (response1, entity1))
+
+    val expectedRequests2 = Map(request2Key -> (upstream2, request2))
+    val expectedResponseMap2 = Map(request2Key -> (response2, entity2))
+
+    val expectedResponse = HttpResponse(entity = "aggregated data")
+
+    val initialState = "initial"
+    val intermediateState = "intermediate"
+
+    class TestAggregator extends GenericAggregator[String, String, String] {
+      override def handleIncomingRequest(
+          authConfig: HeaderAuthConfig
+      )(incomingRequest: HttpRequest,
+        authData: authConfig.AuthData): HandlerResult = {
+        authData should equal(testAuthData)
+        Right((initialState, expectedRequests1))
+      }
+
+      def handleIntermediateResponse(state: String,
+                                     responses: ResponseMap): HandlerResult = {
+        state should equal(initialState)
+        responses should equal(expectedResponseMap1)
+
+        Right((intermediateState, expectedRequests2))
+      }
+
+      def intermediateResponseHandlers: Seq[ResponseHandler] =
+        Seq(handleIntermediateResponse)
+
+      def buildOutgoingResponse(
+          state: String,
+          upstreamResponses: ResponseMap): HttpResponse = {
+        state should equal(intermediateState)
+        upstreamResponses should equal(expectedResponseMap2)
+
+        expectedResponse
+      }
+    }
+
+    val aggregator = new TestAggregator
+
+    "sends requests to upstreams and aggregates responses in multiple steps" in {
+      implicit val stubProxy =
+        new HttpProxy[String](null, null)(null, null, null) {
+          override def request(
+              request: HttpRequest,
+              upstream: Upstream[String]): Future[HttpResponse] = {
+            upstream match {
+              case `upstream1` => Future.successful(response1)
+              case `upstream2` => Future.successful(response2)
+            }
+          }
+        }
+
+      val request = HttpRequest()
+
+      val response =
+        Await.result(aggregator.execute(ac)(request, testAuthData), 10.seconds)
+      response should equal(expectedResponse)
+    }
+  }
+}

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepJsonHydrationAggregatorSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepJsonHydrationAggregatorSpec.scala
@@ -1,0 +1,126 @@
+package com.pagerduty.akka.http.aggregator.aggregator
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
+import com.pagerduty.akka.http.aggregator.AggregatorUpstream
+import com.pagerduty.akka.http.aggregator.support.{
+  TestAuthConfig,
+  TestUpstream
+}
+import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
+import com.pagerduty.akka.http.proxy.{HttpProxy, Upstream}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
+import ujson.Js
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+class OneStepJsonHydrationAggregatorSpec
+    extends TestKit(ActorSystem("OneStepJsonHydrationAggregatorSpec"))
+    with FreeSpecLike
+    with Matchers
+    with MockFactory
+    with ScalaFutures
+    with BeforeAndAfterAll {
+
+  override def afterAll {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  implicit val executionContext = ExecutionContext.global
+  implicit val materializer = ActorMaterializer()
+
+  val ac = new TestAuthConfig
+
+  val testAuthData = "auth-data"
+
+  val upstream1 = TestUpstream(1, "1")
+  val upstream2 = TestUpstream(2, "2")
+
+  "A OneStepJsonHydrationAggregator" - {
+    val request1 = HttpRequest(uri = "/req1")
+    val request2 = HttpRequest(uri = "/req2")
+
+    val entity1 = "{ \"entity\": 1 }"
+    val entity2 = "{ \"entity\": 2 }"
+
+    val entityJson1 = ujson.read(entity1)
+    val entityJson2 = ujson.read(entity2)
+
+    val response1 = HttpResponse(entity = entity1)
+    val response2 = HttpResponse(entity = entity2)
+
+    val reqKey1 = "req1"
+    val reqKey2 = "req2"
+
+    val expectedRequests
+      : Map[String, (AggregatorUpstream[String], HttpRequest)] =
+      Map(reqKey1 -> (upstream1, request1), reqKey2 -> (upstream2, request2))
+    val expectedResponse = HttpResponse(entity = "aggregated data")
+
+    val expectedResponses = Map(reqKey1 -> (response1, entityJson1),
+                                reqKey2 -> (response2, entityJson2))
+
+    class TestOneStepJsonHydrationAggregator
+        extends OneStepJsonHydrationAggregator[String] {
+      override def handleIncomingRequestStateless(
+          authConfig: HeaderAuthConfig
+      )(incomingRequest: HttpRequest,
+        authData: authConfig.AuthData): Either[HttpResponse, RequestMap] = {
+        authData should equal(authData)
+        Right(expectedRequests)
+      }
+
+      override def buildOutgoingJsonResponseStateless(
+          upstreamResponses: Map[String, (HttpResponse, Js.Value)]
+      ): HttpResponse = {
+        upstreamResponses should equal(expectedResponses)
+        expectedResponse
+      }
+    }
+
+    val aggregator = new TestOneStepJsonHydrationAggregator
+
+    "sends requests to upstreams and aggregates the responses" in {
+      implicit val stubProxy =
+        new HttpProxy[String](null, null)(null, null, null) {
+          override def request(
+              request: HttpRequest,
+              upstream: Upstream[String]): Future[HttpResponse] = {
+            upstream match {
+              case `upstream1` => Future.successful(response1)
+              case `upstream2` => Future.successful(response2)
+            }
+          }
+        }
+      val request = HttpRequest()
+
+      val response =
+        Await.result(aggregator.execute(ac)(request, testAuthData), 10.seconds)
+      response should equal(expectedResponse)
+    }
+
+    "fails whole request when one request fails" in {
+      implicit val stubProxy =
+        new HttpProxy[String](null, null)(null, null, null) {
+          override def request(
+              request: HttpRequest,
+              upstream: Upstream[String]): Future[HttpResponse] = {
+            upstream match {
+              case `upstream1` => Future.successful(response1)
+              case `upstream2` =>
+                Future.failed(new RuntimeException("simulated exception"))
+            }
+          }
+        }
+      val request = HttpRequest(uri = "/fail-path")
+
+      val response = aggregator.execute(ac)(request, testAuthData)
+      response.failed.futureValue shouldBe a[RuntimeException]
+    }
+  }
+}

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepJsonHydrationAggregatorSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepJsonHydrationAggregatorSpec.scala
@@ -1,0 +1,114 @@
+package com.pagerduty.akka.http.aggregator.aggregator
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
+import com.pagerduty.akka.http.aggregator.AggregatorUpstream
+import com.pagerduty.akka.http.aggregator.support.{
+  TestAuthConfig,
+  TestUpstream
+}
+import com.pagerduty.akka.http.proxy.{HttpProxy, Upstream}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
+import ujson.Js
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration._
+
+class TwoStepJsonHydrationAggregatorSpec
+    extends TestKit(ActorSystem("TwoStepJsonHydrationAggregatorSpec"))
+    with FreeSpecLike
+    with Matchers
+    with MockFactory
+    with BeforeAndAfterAll {
+
+  override def afterAll {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  implicit val executionContext = ExecutionContext.global
+  implicit val materializer = ActorMaterializer()
+
+  val ac = new TestAuthConfig
+
+  val testAuthData = "auth-data"
+
+  val upstream1 = TestUpstream(1, "1")
+  val upstream2 = TestUpstream(2, "2")
+
+  "A TwoStepJsonHydrationAggregator" - {
+    val request1Key = "request1"
+    val request1 = HttpRequest(uri = "/req1")
+    val request2Key = "request2"
+    val request2 = HttpRequest(uri = "/req2")
+
+    val entity1 = "{ \"entity\": 1 }"
+    val entity2 = "{ \"entity\": 2 }"
+
+    val entityJson1 = ujson.read(entity1)
+    val entityJson2 = ujson.read(entity2)
+
+    val response1 = HttpResponse(entity = entity1)
+    val response2 = HttpResponse(entity = entity2)
+
+    val expectedRequests1 = Map(request1Key -> (upstream1, request1))
+    val expectedResponseMap1 = Map(request1Key -> (response1, entity1))
+
+    val expectedRequests2 = Map(request2Key -> (upstream2, request2))
+    val expectedResponseMap2 = Map(request2Key -> (response2, entity2))
+
+    val expectedResponse = HttpResponse(entity = "aggregated data")
+
+    val initialState = "initial"
+    val intermediateState = "intermediate"
+
+    class TestAggregator extends TwoStepJsonHydrationAggregator[String] {
+      override def handleIncomingRequest(incomingRequest: HttpRequest)
+        : Either[HttpResponse, (AggregatorUpstream[String], HttpRequest)] =
+        Right((upstream1, request1))
+
+      override def handleJsonUpstreamResponse(
+          upstreamResponse: HttpResponse,
+          upstreamJson: Js.Value): RequestMap = {
+        upstreamResponse should equal(response1)
+        upstreamJson should equal(entityJson1)
+
+        expectedRequests2
+      }
+
+      def buildOutgoingJsonResponse(
+          initialUpstreamJson: Js.Value,
+          upstreamResponseMap: Map[String, (HttpResponse, Js.Value)]
+      ): HttpResponse = {
+        initialUpstreamJson should equal(entityJson1)
+        upstreamResponseMap should have size (1)
+        upstreamResponseMap(request2Key) should equal((response2, entityJson2))
+
+        expectedResponse
+      }
+    }
+
+    val aggregator = new TestAggregator
+
+    "sends requests to upstreams and aggregates responses in multiple steps" in {
+      implicit val stubProxy =
+        new HttpProxy[String](null, null)(null, null, null) {
+          override def request(
+              request: HttpRequest,
+              upstream: Upstream[String]): Future[HttpResponse] = {
+            upstream match {
+              case `upstream1` => Future.successful(response1)
+              case `upstream2` => Future.successful(response2)
+            }
+          }
+        }
+      val request = HttpRequest()
+
+      val response =
+        Await.result(aggregator.execute(ac)(request, testAuthData), 10.seconds)
+      response should equal(expectedResponse)
+    }
+  }
+}

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/support/TestAuthConfig.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/support/TestAuthConfig.scala
@@ -1,0 +1,33 @@
+package com.pagerduty.akka.http.aggregator.support
+
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.headers.RawHeader
+import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
+import com.pagerduty.akka.http.requestauthentication.model.AuthenticationData.AuthFailedReason
+import com.pagerduty.akka.http.support.RequestMetadata
+
+import scala.concurrent.Future
+import scala.util.Try
+
+class TestAuthConfig extends HeaderAuthConfig {
+  type Cred = String
+  type AuthData = String
+  type Permission = String
+  type AuthHeader = RawHeader
+
+  def extractCredentials(request: HttpRequest)(
+      implicit reqMeta: RequestMetadata): List[Cred] = ???
+
+  def authenticate(credential: Cred)(
+      implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]] = ???
+
+  def authDataGrantsPermission(
+      authData: AuthData,
+      request: HttpRequest,
+      permission: Option[Permission]
+  )(implicit reqMeta: RequestMetadata): Option[AuthFailedReason] = ???
+
+  def dataToAuthHeader(data: AuthData)(
+      implicit reqMeta: RequestMetadata): AuthHeader = ???
+  def authHeaderName: String = ???
+}

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/support/TestUpstream.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/support/TestUpstream.scala
@@ -1,0 +1,17 @@
+package com.pagerduty.akka.http.aggregator.support
+
+import akka.http.scaladsl.model.HttpRequest
+import com.pagerduty.akka.http.aggregator.AggregatorUpstream
+import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
+import com.pagerduty.akka.http.proxy.CommonHostnameUpstream
+
+case class TestUpstream(port: Int, metricsTag: String)
+    extends CommonHostnameUpstream
+    with AggregatorUpstream[String] {
+  override def prepareAggregatorRequestForDelivery(
+      authConfig: HeaderAuthConfig,
+      request: HttpRequest,
+      modelRequest: HttpRequest
+  ): HttpRequest =
+    request
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.20.0"
+version in ThisBuild := "0.21.0"


### PR DESCRIPTION
A common pattern is to short-circuit the execution of an `Aggregator` if one of the upstream responses is unexpected, or if the initial request is somehow incorrect. Previously, this could have been accomplished by making the `AccumulatedState` an `Either[HttpResponse, SomeState]`, and then modifying the handlers to short-circuit if the state was a `Left[HttpResponse]`. This quickly gets tiresome though. I thought it better to bake this pattern into the generic aggregation code, and that's what this PR does.

Along the way, I cleaned up a couple other things:
- Renamed the `Aggregator` trait to `GenericAggregator`
- Moved the actual aggregation logic into `GenericAggregator` from `AggregatorController`. Now the `AggregatorController` just calls `Aggregator#execute` This is good separation of concerns, and has allowed for independent tests for each `GenericAggregator` subclass. The tests are the same, just moved around a bit.
- Made an `Aggregator` trait that just defines the abstract `execute` method. This allows for other types of aggregation (GraphQL, anyone?) and cleans up the signatures in the `AggregationController` considerably.