### PR TITLE
Improve request transformation and add response transformation.

### DIFF
--- a/akka-http-auth-proxy/src/main/scala/com/pagerduty/akka/http/authproxy/RequestTransformer.scala
+++ b/akka-http-auth-proxy/src/main/scala/com/pagerduty/akka/http/authproxy/RequestTransformer.scala
@@ -1,0 +1,10 @@
+package com.pagerduty.akka.http.authproxy
+
+import akka.http.scaladsl.model.HttpRequest
+
+import scala.concurrent.Future
+
+trait RequestTransformer[AuthData] {
+  def transformRequest(request: HttpRequest,
+                       optAuthData: Option[AuthData]): Future[HttpRequest]
+}

--- a/akka-http-auth-proxy/src/main/scala/com/pagerduty/akka/http/authproxy/ResponseTransformer.scala
+++ b/akka-http-auth-proxy/src/main/scala/com/pagerduty/akka/http/authproxy/ResponseTransformer.scala
@@ -1,0 +1,11 @@
+package com.pagerduty.akka.http.authproxy
+
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
+
+import scala.concurrent.Future
+
+trait ResponseTransformer[AuthData] {
+  def transformResponse(response: HttpResponse,
+                        optAuthData: Option[AuthData]): Future[HttpResponse]
+}

--- a/akka-http-auth-proxy/src/main/scala/com/pagerduty/akka/http/authproxy/StartLineAndHeadersTransformer.scala
+++ b/akka-http-auth-proxy/src/main/scala/com/pagerduty/akka/http/authproxy/StartLineAndHeadersTransformer.scala
@@ -1,0 +1,18 @@
+package com.pagerduty.akka.http.authproxy
+
+import akka.http.scaladsl.model.HttpRequest
+import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
+
+import scala.concurrent.Future
+
+trait StartLineAndHeadersTransformer[AuthData]
+    extends RequestTransformer[AuthData] {
+  override def transformRequest(
+      request: HttpRequest,
+      optAuthData: Option[AuthData]): Future[HttpRequest] = {
+    Future.successful(transformStartLineAndHeaders(request, optAuthData))
+  }
+
+  def transformStartLineAndHeaders(request: HttpRequest,
+                                   optAuthData: Option[AuthData]): HttpRequest
+}

--- a/akka-http-auth-proxy/src/main/scala/com/pagerduty/akka/http/authproxy/StatusAndHeadersTransformer.scala
+++ b/akka-http-auth-proxy/src/main/scala/com/pagerduty/akka/http/authproxy/StatusAndHeadersTransformer.scala
@@ -1,0 +1,17 @@
+package com.pagerduty.akka.http.authproxy
+
+import akka.http.scaladsl.model.HttpResponse
+
+import scala.concurrent.Future
+
+trait StatusAndHeadersTransformer[AuthData]
+    extends ResponseTransformer[AuthData] {
+  override def transformResponse(
+      response: HttpResponse,
+      optAuthData: Option[AuthData]): Future[HttpResponse] = {
+    Future.successful(transformStatusAndHeaders(response, optAuthData))
+  }
+
+  def transformStatusAndHeaders(response: HttpResponse,
+                                optAuthData: Option[AuthData]): HttpResponse
+}

--- a/akka-http-header-authentication/src/main/scala/com/pagerduty/akka/http/headerauthentication/HeaderAuthenticator.scala
+++ b/akka-http-header-authentication/src/main/scala/com/pagerduty/akka/http/headerauthentication/HeaderAuthenticator.scala
@@ -16,7 +16,8 @@ trait HeaderAuthenticator extends MetadataLogging {
   )(request: HttpRequest,
     stripAuthorizationHeader: Boolean = true,
     requiredPermission: Option[authConfig.Permission] = None)(
-      handler: HttpRequest => Future[HttpResponse])(
+      handler: (HttpRequest,
+                Option[authConfig.AuthData]) => Future[HttpResponse])(
       implicit reqMeta: RequestMetadata): Future[HttpResponse] = {
     requestAuthenticator.authenticate(authConfig)(request,
                                                   stripAuthorizationHeader,
@@ -28,7 +29,7 @@ trait HeaderAuthenticator extends MetadataLogging {
             log.debug("Authentication failed, not adding auth header!")
             request
         }
-        handler(possiblyAuthedRequest)
+        handler(possiblyAuthedRequest, optAuthData)
     }
   }
 

--- a/akka-http-header-authentication/src/test/scala/com/pagerduty/akka/http/headerauthentication/HeaderAuthenticatorSpec.scala
+++ b/akka-http-header-authentication/src/test/scala/com/pagerduty/akka/http/headerauthentication/HeaderAuthenticatorSpec.scala
@@ -80,7 +80,7 @@ class HeaderAuthenticatorSpec
       val headerAuth = buildHeaderAuthenticator(data)
       val request = HttpRequest()
 
-      val handler = (req: HttpRequest) => {
+      val handler = (req: HttpRequest, optAuthData: Option[String]) => {
         authHeader(req) should equal(Some(authHeader))
         Future.successful(HttpResponse())
       }
@@ -93,7 +93,7 @@ class HeaderAuthenticatorSpec
     "does not add auth header when authentication fails" in {
       val headerAuth = buildHeaderAuthenticator(None)
       val request = HttpRequest()
-      val handler = (req: HttpRequest) => {
+      val handler = (req: HttpRequest, optAuthData: Option[String]) => {
         authHeader(req) should equal(None)
         Future.successful(HttpResponse())
       }

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val akkaHttpVersion = "10.0.11"
 lazy val scalaMetricsVersion = "2.0.0"
 lazy val scalaTestVersion = "3.0.4"
 lazy val scalaMockVersion = "4.1.0"
-lazy val akkaSupportHttpVersion = "0.5.0"
+lazy val akkaSupportHttpVersion = "0.6.4"
 lazy val logbackVersion = "1.2+"
 
 lazy val sharedSettings = Seq(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.21.0"
+version in ThisBuild := "0.22.0"


### PR DESCRIPTION
Previously, we had request transformation in the form of passing a `HttpRequest => HttpRequest` into the `AuthProxyController`. This sort-of worked, but it was done prior to authentication, which did not allow auth data to be used inside the transformation function.

This transformation is beefed up now into a `trait RequestTransformer` that runs after authentication and has access to the auth data in the transformation function. It's also generalized to handle the case where reading the request entity might be required (i.e. it returns a `Future[HttpRequest]` instead of a plain `HttpRequest`). Simplicity of the previous interface is maintained via `StartLineAndHeadersTransformer`, where it is expected that users will transform the start line and headers, but not the entity.

A `ResponseTransformer` trait is added in this same style, along with a simpler `StatusAndHeadersTransformer` for when no entity transformation is required.

Finally, various convenience methods were added to `AuthProxyController` to maintain the flexibility of the existing API. Maintaining API flexibility partly motivated the move to `trait`s instead of functions, since type erasure was causing conflicts between the various convenience functions when using functions.