### PR TITLE
Correct signatures of Aggregator methods for type safety

### DIFF
--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/AggregatorController.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/AggregatorController.scala
@@ -20,7 +20,7 @@ trait AggregatorController[AuthConfig <: HeaderAuthConfig, AddressingConfig] {
 
   def prefixAggregatorRoute(
       pathMatcher: PathMatcher[Unit],
-      aggregator: Aggregator[AddressingConfig],
+      aggregator: Aggregator[AuthConfig#AuthData, AddressingConfig],
       requiredPermission: Option[AuthConfig#Permission] = None
   ): Route = {
     pathPrefix(pathMatcher) {
@@ -29,7 +29,7 @@ trait AggregatorController[AuthConfig <: HeaderAuthConfig, AddressingConfig] {
   }
 
   def aggregatorRoute(
-      aggregator: Aggregator[AddressingConfig],
+      aggregator: Aggregator[AuthConfig#AuthData, AddressingConfig],
       requiredPermission: Option[AuthConfig#Permission] = None
   ): Route = {
     extractRequest { incomingRequest =>

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/Aggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/Aggregator.scala
@@ -7,11 +7,10 @@ import com.pagerduty.akka.http.proxy.HttpProxy
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait Aggregator[AddressingConfig] {
+trait Aggregator[AuthData, AddressingConfig] {
   def execute(authConfig: HeaderAuthConfig)(authedRequest: HttpRequest,
-                                            authData: authConfig.AuthData)(
+                                            authData: AuthData)(
       implicit httpProxy: HttpProxy[AddressingConfig],
       executionContext: ExecutionContext,
       materializer: Materializer): Future[HttpResponse]
-
 }

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepAggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepAggregator.scala
@@ -4,8 +4,8 @@ import akka.NotUsed
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import com.pagerduty.akka.http.requestauthentication.model.AuthenticationConfig
 
-trait OneStepAggregator[RequestKey, AddressingConfig]
-    extends GenericAggregator[RequestKey, NotUsed, AddressingConfig] {
+trait OneStepAggregator[AuthData, RequestKey, AddressingConfig]
+    extends GenericAggregator[AuthData, RequestKey, NotUsed, AddressingConfig] {
 
   def intermediateResponseHandlers: Seq[ResponseHandler] = Seq()
 

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepJsonHydrationAggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepJsonHydrationAggregator.scala
@@ -2,9 +2,6 @@ package com.pagerduty.akka.http.aggregator.aggregator
 
 import akka.NotUsed
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
-import com.pagerduty.akka.http.aggregator.AggregatorUpstream
-import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
-import com.pagerduty.akka.http.requestauthentication.model.AuthenticationConfig
 import ujson.Js
 
 /**
@@ -23,25 +20,22 @@ import ujson.Js
   * If any of these assumptions are untrue, look at using a supertype of this trait instead. Also, tell #core about your
   * use case!
   */
-trait OneStepJsonHydrationAggregator[AddressingConfig]
-    extends OneStepAggregator[String, AddressingConfig] {
+trait OneStepJsonHydrationAggregator[AuthData, AddressingConfig]
+    extends OneStepAggregator[AuthData, String, AddressingConfig] {
 
   // implement these two methods
   def handleIncomingRequestStateless(
-      authConfig: HeaderAuthConfig
-  )(incomingRequest: HttpRequest,
-    authData: authConfig.AuthData): Either[HttpResponse, RequestMap]
+      incomingRequest: HttpRequest,
+      authData: AuthData): Either[HttpResponse, RequestMap]
 
   def buildOutgoingJsonResponseStateless(
       upstreamJsonResponses: Map[String, (HttpResponse, Js.Value)])
     : HttpResponse
 
   // the rest is internal implementation
-  override def handleIncomingRequest(
-      authConfig: HeaderAuthConfig
-  )(incomingRequest: HttpRequest,
-    authData: authConfig.AuthData): HandlerResult = {
-    handleIncomingRequestStateless(authConfig)(incomingRequest, authData) match {
+  override def handleIncomingRequest(incomingRequest: HttpRequest,
+                                     authData: AuthData): HandlerResult = {
+    handleIncomingRequestStateless(incomingRequest, authData) match {
       case Right(requests) => Right(NotUsed, requests)
       case Left(response) => Left(response)
     }

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepAggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepAggregator.scala
@@ -1,7 +1,11 @@
 package com.pagerduty.akka.http.aggregator.aggregator
 
-trait TwoStepAggregator[RequestKey, AccumulatedState, AddressingConfig]
-    extends GenericAggregator[RequestKey, AccumulatedState, AddressingConfig] {
+trait TwoStepAggregator[
+    AuthData, RequestKey, AccumulatedState, AddressingConfig]
+    extends GenericAggregator[AuthData,
+                              RequestKey,
+                              AccumulatedState,
+                              AddressingConfig] {
 
   def handleUpstreamResponses(initialState: AccumulatedState,
                               upstreamResponseMap: ResponseMap): HandlerResult

--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepJsonHydrationAggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepJsonHydrationAggregator.scala
@@ -24,8 +24,8 @@ import ujson.Js
   * If any of these assumptions are untrue, look at using a supertype of this trait instead. Also, tell #core about your
   * use case!
   */
-trait TwoStepJsonHydrationAggregator[AddressingConfig]
-    extends TwoStepAggregator[String, Js.Value, AddressingConfig] {
+trait TwoStepJsonHydrationAggregator[AuthData, AddressingConfig]
+    extends TwoStepAggregator[AuthData, String, Js.Value, AddressingConfig] {
 
   // implement these three methods
   def handleIncomingRequest(incomingRequest: HttpRequest)
@@ -43,10 +43,8 @@ trait TwoStepJsonHydrationAggregator[AddressingConfig]
   private val emptyState = ujson.read("{}")
   private val initialRequestKey = "initial"
 
-  override def handleIncomingRequest(
-      authConfig: HeaderAuthConfig
-  )(incomingRequest: HttpRequest,
-    authData: authConfig.AuthData): HandlerResult = {
+  override def handleIncomingRequest(incomingRequest: HttpRequest,
+                                     authData: AuthData): HandlerResult = {
     handleIncomingRequest(incomingRequest) match {
       case Right(initialRequest) =>
         Right((emptyState, Map(initialRequestKey -> initialRequest)))

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/AggregatorControllerSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/AggregatorControllerSpec.scala
@@ -60,10 +60,9 @@ class AggregatorControllerSpec
 
     "with a simple test Aggregator" - {
 
-      class TestAggregator extends Aggregator[String] {
-        def execute(authConfig: HeaderAuthConfig)(
-            authedRequest: HttpRequest,
-            authData: authConfig.AuthData)(
+      class TestAggregator extends Aggregator[String, String] {
+        def execute(authConfig: HeaderAuthConfig)(authedRequest: HttpRequest,
+                                                  authData: String)(
             implicit httpProxy: HttpProxy[String],
             executionContext: ExecutionContext,
             materializer: Materializer): Future[HttpResponse] = {

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/GenericAggregatorSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/GenericAggregatorSpec.scala
@@ -69,11 +69,10 @@ class GenericAggregatorSpec
     val initialFailureResponse = HttpResponse(StatusCodes.MethodNotAllowed)
     val intermediateFailureResponse = HttpResponse(StatusCodes.BadGateway)
 
-    class TestAggregator extends GenericAggregator[String, String, String] {
-      override def handleIncomingRequest(
-          authConfig: HeaderAuthConfig
-      )(incomingRequest: HttpRequest,
-        authData: authConfig.AuthData): HandlerResult = {
+    class TestAggregator
+        extends GenericAggregator[String, String, String, String] {
+      override def handleIncomingRequest(incomingRequest: HttpRequest,
+                                         authData: String): HandlerResult = {
         authData should equal(testAuthData)
 
         if (incomingRequest.method == HttpMethods.GET) {

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepJsonHydrationAggregatorSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepJsonHydrationAggregatorSpec.scala
@@ -66,11 +66,10 @@ class OneStepJsonHydrationAggregatorSpec
                                 reqKey2 -> (response2, entityJson2))
 
     class TestOneStepJsonHydrationAggregator
-        extends OneStepJsonHydrationAggregator[String] {
+        extends OneStepJsonHydrationAggregator[String, String] {
       override def handleIncomingRequestStateless(
-          authConfig: HeaderAuthConfig
-      )(incomingRequest: HttpRequest,
-        authData: authConfig.AuthData): Either[HttpResponse, RequestMap] = {
+          incomingRequest: HttpRequest,
+          authData: String): Either[HttpResponse, RequestMap] = {
         authData should equal(authData)
         Right(expectedRequests)
       }

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepJsonHydrationAggregatorSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepJsonHydrationAggregatorSpec.scala
@@ -64,7 +64,8 @@ class TwoStepJsonHydrationAggregatorSpec
     val initialState = "initial"
     val intermediateState = "intermediate"
 
-    class TestAggregator extends TwoStepJsonHydrationAggregator[String] {
+    class TestAggregator
+        extends TwoStepJsonHydrationAggregator[String, String] {
       override def handleIncomingRequest(incomingRequest: HttpRequest)
         : Either[HttpResponse, (AggregatorUpstream[String], HttpRequest)] =
         Right((upstream1, request1))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.21.0"
+version in ThisBuild := "0.22.0"


### PR DESCRIPTION
Previously, the `authData` passed to the various user-facing `GenericAggregator` methods was useless - it was a non-specific type. This PR tweaks varies types and signatures to allow it to be specific. Now, implementors of the `Aggregator` class specify which `AuthData` type they expect to handle. If an `Aggregator` handling an incorrect type of `AuthData` (i.e. one that doesn't match `authConfig.AuthData`) is passed to `aggregatorRoute` and friends, a compilation error results.

As a bonus, the signatures of the user-facing methods are much simpler.

Needs a version bump before merging.