### PR TITLE
Delegate proxy request modification to Upstream

### DIFF
--- a/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/HttpProxy.scala
+++ b/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/HttpProxy.scala
@@ -22,13 +22,12 @@ class HttpProxy[AddressingConfig](
 
   def request(request: HttpRequest,
               upstream: Upstream[AddressingConfig]): Future[HttpResponse] = {
-    val targetedRequest =
-      upstream.addressRequestWithOverrides(request, addressingConfig)
+    val addressedRequest =
+      upstream
+        .addressRequestWithOverrides(request, addressingConfig)
+        .removeHeader(TimeoutAccessHeaderName) // Akka HTTP server adds the Timeout-Access for internal reasons, but it should not be proxied
 
-    val proxyRequest =
-      targetedRequest.removeHeader(TimeoutAccessHeaderName) // Akka HTTP server adds the Timeout-Access for internal reasons, but it should not be proxied
-
-    val preparedProxyRequest = upstream.prepareRequestForDelivery(proxyRequest)
+    val preparedProxyRequest = upstream.prepareRequestForDelivery(addressedRequest)
 
     val stopwatch = Stopwatch.start()
     val response = httpClient(preparedProxyRequest)

--- a/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/HttpProxy.scala
+++ b/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/HttpProxy.scala
@@ -27,7 +27,8 @@ class HttpProxy[AddressingConfig](
         .addressRequestWithOverrides(request, addressingConfig)
         .removeHeader(TimeoutAccessHeaderName) // Akka HTTP server adds the Timeout-Access for internal reasons, but it should not be proxied
 
-    val preparedProxyRequest = upstream.prepareRequestForDelivery(addressedRequest)
+    val preparedProxyRequest =
+      upstream.prepareRequestForDelivery(addressedRequest)
 
     val stopwatch = Stopwatch.start()
     val response = httpClient(preparedProxyRequest)

--- a/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/Upstream.scala
+++ b/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/Upstream.scala
@@ -44,6 +44,8 @@ trait Upstream[AddressingConfig] {
 
     request.withUri(targetedUri)
   }
+
+  def prepareRequestForDelivery(request: HttpRequest): HttpRequest = request
 }
 
 trait CommonHostnameUpstream extends Upstream[String] {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.23.0"
+version in ThisBuild := "0.24.0"


### PR DESCRIPTION
In some cases, modification of proxied requests is dependent on the `Upstream`. This PR delegates that modification functionality entirely to the `Upstream`.

Also, removed `Connnection` header modification which may not apply to all `Upstream`s.