### PR TITLE
WebSocket support in HttpProxy

### DIFF
--- a/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/Aggregator.scala
+++ b/akka-http-aggregator/src/main/scala/com/pagerduty/akka/http/aggregator/aggregator/Aggregator.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.stream.Materializer
 import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
 import com.pagerduty.akka.http.proxy.HttpProxy
+import com.pagerduty.akka.http.support.RequestMetadata
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -12,5 +13,6 @@ trait Aggregator[AuthData, AddressingConfig] {
                                             authData: AuthData)(
       implicit httpProxy: HttpProxy[AddressingConfig],
       executionContext: ExecutionContext,
-      materializer: Materializer): Future[HttpResponse]
+      materializer: Materializer,
+      reqMeta: RequestMetadata): Future[HttpResponse]
 }

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/AggregatorControllerSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/AggregatorControllerSpec.scala
@@ -65,7 +65,8 @@ class AggregatorControllerSpec
                                                   authData: String)(
             implicit httpProxy: HttpProxy[String],
             executionContext: ExecutionContext,
-            materializer: Materializer): Future[HttpResponse] = {
+            materializer: Materializer,
+            reqMeta: RequestMetadata): Future[HttpResponse] = {
           authData should equal(testAuthData)
           Future.successful(expectedResponse)
         }

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepJsonHydrationAggregatorSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/OneStepJsonHydrationAggregatorSpec.scala
@@ -11,6 +11,7 @@ import com.pagerduty.akka.http.aggregator.support.{
 }
 import com.pagerduty.akka.http.headerauthentication.model.HeaderAuthConfig
 import com.pagerduty.akka.http.proxy.{HttpProxy, Upstream}
+import com.pagerduty.akka.http.support.RequestMetadata
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
@@ -33,6 +34,7 @@ class OneStepJsonHydrationAggregatorSpec
 
   implicit val executionContext = ExecutionContext.global
   implicit val materializer = ActorMaterializer()
+  implicit val reqMeta = RequestMetadata.fromRequest(HttpRequest())
 
   val ac = new TestAuthConfig
 
@@ -87,9 +89,9 @@ class OneStepJsonHydrationAggregatorSpec
     "sends requests to upstreams and aggregates the responses" in {
       implicit val stubProxy =
         new HttpProxy[String](null, null)(null, null, null) {
-          override def request(
-              request: HttpRequest,
-              upstream: Upstream[String]): Future[HttpResponse] = {
+          override def request(request: HttpRequest,
+                               upstream: Upstream[String])(
+              implicit reqMeta: RequestMetadata): Future[HttpResponse] = {
             upstream match {
               case `upstream1` => Future.successful(response1)
               case `upstream2` => Future.successful(response2)
@@ -106,9 +108,9 @@ class OneStepJsonHydrationAggregatorSpec
     "fails whole request when one request fails" in {
       implicit val stubProxy =
         new HttpProxy[String](null, null)(null, null, null) {
-          override def request(
-              request: HttpRequest,
-              upstream: Upstream[String]): Future[HttpResponse] = {
+          override def request(request: HttpRequest,
+                               upstream: Upstream[String])(
+              implicit reqMeta: RequestMetadata): Future[HttpResponse] = {
             upstream match {
               case `upstream1` => Future.successful(response1)
               case `upstream2` =>

--- a/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepJsonHydrationAggregatorSpec.scala
+++ b/akka-http-aggregator/src/test/scala/com/pagerduty/akka/http/aggregator/aggregator/TwoStepJsonHydrationAggregatorSpec.scala
@@ -10,6 +10,7 @@ import com.pagerduty.akka.http.aggregator.support.{
   TestUpstream
 }
 import com.pagerduty.akka.http.proxy.{HttpProxy, Upstream}
+import com.pagerduty.akka.http.support.RequestMetadata
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
 import ujson.Js
@@ -30,6 +31,7 @@ class TwoStepJsonHydrationAggregatorSpec
 
   implicit val executionContext = ExecutionContext.global
   implicit val materializer = ActorMaterializer()
+  implicit val reqMeta = RequestMetadata.fromRequest(HttpRequest())
 
   val ac = new TestAuthConfig
 
@@ -96,9 +98,9 @@ class TwoStepJsonHydrationAggregatorSpec
     "sends requests to upstreams and aggregates responses in multiple steps" in {
       implicit val stubProxy =
         new HttpProxy[String](null, null)(null, null, null) {
-          override def request(
-              request: HttpRequest,
-              upstream: Upstream[String]): Future[HttpResponse] = {
+          override def request(request: HttpRequest,
+                               upstream: Upstream[String])(
+              implicit reqMeta: RequestMetadata): Future[HttpResponse] = {
             upstream match {
               case `upstream1` => Future.successful(response1)
               case `upstream2` => Future.successful(response2)

--- a/akka-http-auth-proxy/src/it/scala/com/pagerduty/akka/http/authproxy/AuthProxyBehaviourSpec.scala
+++ b/akka-http-auth-proxy/src/it/scala/com/pagerduty/akka/http/authproxy/AuthProxyBehaviourSpec.scala
@@ -1,11 +1,18 @@
 package com.pagerduty.akka.http.authproxy
 
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, HttpResponse, Uri}
+import akka.http.scaladsl.model.ws._
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import com.github.tomakehurst.wiremock.http.Fault
 import com.pagerduty.akka.http.authproxy.support.{
   IntegrationSpec,
   TestAuthConfig
 }
 import scalaj.http.{Http => HttpClient}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class AuthProxyBehaviourSpec extends IntegrationSpec {
   import com.github.tomakehurst.wiremock.client.WireMock._
@@ -216,6 +223,60 @@ class AuthProxyBehaviourSpec extends IntegrationSpec {
         val r = HttpClient(url(s"$path/garbage")).asString
         r.code should equal(expectedStatus)
       }
+    }
+
+    "proxies WebSockets" in {
+      // fake upstream WebSocket server, based on https://github.com/akka/akka-http/blob/v10.1.5/docs/src/test/scala/docs/http/scaladsl/server/WebSocketExampleSpec.scala
+      val stubWebSocketService =
+        Flow[Message]
+          .mapConcat {
+            case tm: TextMessage.Strict =>
+              TextMessage.Strict(s"Hello ${tm.text}") :: Nil
+            case _ =>
+              throw new RuntimeException(
+                "Unexpected message received in test server")
+          }
+
+      val requestHandler: HttpRequest => HttpResponse = {
+        case req @ HttpRequest(HttpMethods.GET, Uri.Path("/ws"), _, _, _) =>
+          req.header[UpgradeToWebSocket] match {
+            case Some(upgrade) =>
+              upgrade.handleMessages(stubWebSocketService)
+            case None =>
+              HttpResponse(400, entity = "Not a valid websocket request!")
+          }
+        case r: HttpRequest =>
+          r.discardEntityBytes() // important to drain incoming HTTP Entity stream
+          HttpResponse(404, entity = "Unknown resource!")
+      }
+
+      val bindingFuture =
+        Http().bindAndHandleSync(requestHandler,
+                                 interface = "localhost",
+                                 port = 10100)
+
+      // a simple WebSocket client
+      val sink = Sink.head[Message]
+
+      val sendSource = Source.single(TextMessage("test"))
+
+      val flow = Flow.fromSinkAndSourceMat(sink, sendSource)(Keep.left)
+
+      // send a WebSocket request to our server under test
+      val resp = Http().singleWebSocketRequest(
+        WebSocketRequest("ws://localhost:1234/ws"),
+        flow)
+
+      // wait for the response message and make sure it matches what the stub upstream should give
+      val receivedMessage = Await.result(resp._2, 1.second)
+      receivedMessage match {
+        case tm: TextMessage.Strict => tm.text should equal("Hello test")
+        case _ =>
+          throw new RuntimeException("Received unexpected message in test")
+      }
+
+      bindingFuture
+        .flatMap(_.unbind()) // trigger unbinding from the port
     }
   }
 }

--- a/akka-http-auth-proxy/src/it/scala/com/pagerduty/akka/http/authproxy/support/HttpServer.scala
+++ b/akka-http-auth-proxy/src/it/scala/com/pagerduty/akka/http/authproxy/support/HttpServer.scala
@@ -25,6 +25,7 @@ class HttpServer(
     val httpInterface: String,
     val port: Int,
     val servicePort: Int,
+    val wsPort: Int,
     val httpProxy: HttpProxy[String]
 )(implicit actorSystem: ActorSystem,
   materializer: ActorMaterializer,
@@ -51,6 +52,13 @@ class HttpServer(
     val port = servicePort
     val metricsTag = "test"
   }
+
+  val wsUpstream = new CommonHostnameUpstream {
+    override def port = wsPort
+
+    override def metricsTag = "test"
+  }
+
   val httpRoutes = {
 
     (handleExceptions(proxyExceptionHandler)) {
@@ -60,7 +68,9 @@ class HttpServer(
                          IncidentsPermission) ~
         prefixProxyRoute("api" / "v2" / "schedules",
                          incidentUpstream,
-                         SchedulesPermission)
+                         SchedulesPermission) ~
+        prefixProxyRoute("ws", wsUpstream)
+
     }
   }
 

--- a/akka-http-auth-proxy/src/it/scala/com/pagerduty/akka/http/authproxy/support/IntegrationSpec.scala
+++ b/akka-http-auth-proxy/src/it/scala/com/pagerduty/akka/http/authproxy/support/IntegrationSpec.scala
@@ -48,7 +48,7 @@ trait IntegrationSpec
   var mockAs: WireMockServer = _
 
   override def beforeAll(): Unit = {
-    as = ActorSystem("bff-public-api-test")
+    as = ActorSystem("test-system")
     ec = as.dispatcher
     m = ActorMaterializer()
     implicit val metrics = NullMetrics
@@ -66,7 +66,7 @@ trait IntegrationSpec
     }
 
     val httpProxy = new HttpProxy("localhost", httpClient)
-    s = new HttpServer(host, port, servicePort, httpProxy)
+    s = new HttpServer(host, port, servicePort, 10100, httpProxy)
 
     mockService = new WireMockServer(options().port(servicePort))
     mockService.start()

--- a/akka-http-auth-proxy/src/test/scala/com/pagerduty/akka/http/authproxy/AuthProxyControllerSpec.scala
+++ b/akka-http-auth-proxy/src/test/scala/com/pagerduty/akka/http/authproxy/AuthProxyControllerSpec.scala
@@ -63,8 +63,8 @@ class AuthProxyControllerSpec
     val expectedTransformedResponse = HttpResponse(302)
 
     val proxyStub = new HttpProxy[String](null, null)(null, null, null) {
-      override def request(request: HttpRequest,
-                           upstream: Upstream[String]): Future[HttpResponse] =
+      override def request(request: HttpRequest, upstream: Upstream[String])(
+          implicit reqMeta: RequestMetadata): Future[HttpResponse] =
         if (request.uri.toString.contains("transformed")) {
           Future.successful(expectedTransformedResponse)
         } else {

--- a/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/HttpClient.scala
+++ b/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/HttpClient.scala
@@ -1,0 +1,19 @@
+package com.pagerduty.akka.http.proxy
+
+import akka.http.scaladsl.model.ws.{
+  Message,
+  WebSocketRequest,
+  WebSocketUpgradeResponse
+}
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.scaladsl.Flow
+
+import scala.concurrent.Future
+
+trait HttpClient {
+  def executeRequest(request: HttpRequest): Future[HttpResponse]
+
+  def executeWebSocketRequest[T](request: WebSocketRequest,
+                                 clientFlow: Flow[Message, Message, T])
+    : (Future[WebSocketUpgradeResponse], T)
+}

--- a/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/HttpProxy.scala
+++ b/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/HttpProxy.scala
@@ -1,27 +1,39 @@
 package com.pagerduty.akka.http.proxy
 
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.model.ws._
+import akka.http.scaladsl.model.{HttpHeader, HttpRequest, HttpResponse}
 import akka.stream.Materializer
-import com.pagerduty.akka.http.support.MetadataLogging
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import com.pagerduty.akka.http.support.{MetadataLogging, RequestMetadata}
 import com.pagerduty.metrics.{Metrics, Stopwatch}
 
+import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 object HttpProxy {
   val TimeoutAccessHeaderName = "Timeout-Access"
+
+  val WebSocketHeadersToFilter = Set(
+    "Sec-WebSocket-Accept",
+    "Sec-WebSocket-Version",
+    "Sec-WebSocket-Key",
+    "Sec-WebSocket-Extensions",
+    "UpgradeToWebSocket",
+    "Upgrade"
+  ).map(_.toLowerCase)
 }
 
 class HttpProxy[AddressingConfig](
     addressingConfig: AddressingConfig,
-    httpClient: HttpRequest => Future[HttpResponse],
+    httpClient: HttpClient,
     entityConsumptionTimeout: FiniteDuration = 20.seconds
 )(implicit ec: ExecutionContext, materializer: Materializer, metrics: Metrics)
     extends MetadataLogging {
   import HttpProxy._
 
-  def request(request: HttpRequest,
-              upstream: Upstream[AddressingConfig]): Future[HttpResponse] = {
+  def request(request: HttpRequest, upstream: Upstream[AddressingConfig])(
+      implicit reqMeta: RequestMetadata): Future[HttpResponse] = {
     val addressedRequest =
       upstream
         .addressRequestWithOverrides(request, addressingConfig)
@@ -31,17 +43,69 @@ class HttpProxy[AddressingConfig](
       upstream.prepareRequestForDelivery(addressedRequest)
 
     val stopwatch = Stopwatch.start()
-    val response = httpClient(preparedProxyRequest)
 
-    response.flatMap { r =>
+    val response = preparedProxyRequest.header[UpgradeToWebSocket] match {
+      case Some(upgrade) =>
+        proxyWebSocketRequest(preparedProxyRequest, upgrade)
+      case None =>
+        proxyHttpRequest(preparedProxyRequest)
+    }
+
+    response.map { r =>
       val elapsed = stopwatch.elapsed().toMicros.toInt
       metrics.histogram("upstream_response_time",
                         elapsed,
                         "upstream" -> upstream.metricsTag)
+      r
+    }
+  }
 
+  private def proxyHttpRequest(request: HttpRequest): Future[HttpResponse] = {
+    val response = httpClient.executeRequest(request)
+    response.flatMap { r =>
       r.entity.withoutSizeLimit().toStrict(entityConsumptionTimeout).map { e =>
         r.withEntity(e)
       }
     }
+  }
+
+  private def proxyWebSocketRequest(request: HttpRequest,
+                                    upgrade: UpgradeToWebSocket)(
+      implicit reqMeta: RequestMetadata): Future[HttpResponse] = {
+    // this code heavily inspired by https://github.com/DataBiosphere/leonardo/blob/develop/src/main/scala/org/broadinstitute/dsde/workbench/leonardo/service/ProxyService.scala
+    val flow =
+      Flow.fromSinkAndSourceMat(Sink.asPublisher[Message](fanout = false),
+                                Source.asSubscriber[Message])(Keep.both)
+
+    val (responseFuture, (publisher, subscriber)) =
+      httpClient.executeWebSocketRequest(
+        WebSocketRequest(
+          request.uri.withScheme("ws"),
+          extraHeaders = filterWebSocketHeaders(request.headers),
+          upgrade.requestedProtocols.headOption),
+        flow
+      )
+
+    responseFuture.map {
+      case ValidUpgrade(response, chosenSubprotocol) =>
+        val webSocketResponse = upgrade.handleMessages(
+          Flow.fromSinkAndSource(Sink.fromSubscriber(subscriber),
+                                 Source.fromPublisher(publisher)),
+          chosenSubprotocol
+        )
+        webSocketResponse.withHeaders(
+          webSocketResponse.headers ++ filterWebSocketHeaders(
+            response.headers))
+
+      case InvalidUpgradeResponse(response, cause) =>
+        log.warn(s"WebSocket upgrade response was invalid: $cause")
+        response
+    }
+  }
+
+  private def filterWebSocketHeaders(
+      headers: immutable.Seq[HttpHeader]): immutable.Seq[HttpHeader] = {
+    headers.filterNot(header =>
+      WebSocketHeadersToFilter.contains(header.lowercaseName()))
   }
 }

--- a/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/ProxyController.scala
+++ b/akka-http-proxy/src/main/scala/com/pagerduty/akka/http/proxy/ProxyController.scala
@@ -2,6 +2,7 @@ package com.pagerduty.akka.http.proxy
 
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import com.pagerduty.akka.http.support.RequestMetadata
 
 trait ProxyController[AddressingConfig] {
 
@@ -9,6 +10,7 @@ trait ProxyController[AddressingConfig] {
 
   def proxyRouteUnauthenticated(upstream: Upstream[AddressingConfig]): Route =
     extractRequest { request =>
+      implicit val reqMeta = RequestMetadata.fromRequest(request)
       complete {
         httpProxy.request(request, upstream)
       }

--- a/akka-http-proxy/src/test/scala/com/pagerduty/akka/http/proxy/HttpProxySpec.scala
+++ b/akka-http-proxy/src/test/scala/com/pagerduty/akka/http/proxy/HttpProxySpec.scala
@@ -3,15 +3,37 @@ package com.pagerduty.akka.http.proxy
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri.Authority
 import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.ws.{
+  Message,
+  WebSocketRequest,
+  WebSocketUpgradeResponse
+}
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
 import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Flow
+import com.pagerduty.akka.http.support.RequestMetadata
 import com.pagerduty.metrics.NullMetrics
 import org.scalatest.{FreeSpecLike, Matchers}
 
 import scala.concurrent.Future
 
 class HttpProxySpec extends FreeSpecLike with Matchers {
+
+  def buildHttpClient(
+      requestExecutor: HttpRequest => Future[HttpResponse]): HttpClient = {
+    new HttpClient {
+      def executeRequest(req: HttpRequest): Future[HttpResponse] =
+        requestExecutor(req)
+
+      def executeWebSocketRequest[T](request: WebSocketRequest,
+                                     clientFlow: Flow[Message, Message, T])
+        : (Future[WebSocketUpgradeResponse], T) = ???
+    }
+  }
+
   "An HttpProxy" - {
+    implicit val reqMeta = RequestMetadata.fromRequest(HttpRequest())
+
     val headerKey = "x-test-header"
     val headerValue = "test"
     val additionalHeader = RawHeader(headerKey, headerValue)
@@ -31,14 +53,14 @@ class HttpProxySpec extends FreeSpecLike with Matchers {
     val response = HttpResponse()
 
     "removes the Timeout-Header if it exists before proxying" in {
-      val httpClient = (req: HttpRequest) => {
+      val httpClient = buildHttpClient(req => {
         if (req.headers.exists(_.is("timeout-access"))) {
           throw new Exception(
             "The Timeout-Access header is not being removed as we expect")
         }
 
         Future.successful(response)
-      }
+      })
 
       val p = new HttpProxy("localhost", httpClient)
 
@@ -47,7 +69,7 @@ class HttpProxySpec extends FreeSpecLike with Matchers {
     }
 
     "prepares the request before proxying" in {
-      val httpClient = (req: HttpRequest) => {
+      val httpClient = buildHttpClient((req: HttpRequest) => {
         req.headers.find(_.is(headerKey)) match {
           case Some(h) if h.value() == headerValue => // it works!
           case _ =>
@@ -56,7 +78,7 @@ class HttpProxySpec extends FreeSpecLike with Matchers {
         }
 
         Future.successful(response)
-      }
+      })
 
       val p = new HttpProxy("localhost", httpClient)
 
@@ -65,13 +87,13 @@ class HttpProxySpec extends FreeSpecLike with Matchers {
 
     "proxies the request to the given authority" in {
       val authority = Authority(Uri.Host("localhost"), 1234)
-      val httpClient = (req: HttpRequest) => {
+      val httpClient = buildHttpClient((req: HttpRequest) => {
         if (req.uri.authority != authority) {
           throw new Exception(
             "Authority on proxied request not being set as expected")
         }
         Future.successful(response)
-      }
+      })
 
       val p = new HttpProxy("localhost", httpClient)
 

--- a/akka-http-proxy/src/test/scala/com/pagerduty/akka/http/proxy/ProxyControllerSpec.scala
+++ b/akka-http-proxy/src/test/scala/com/pagerduty/akka/http/proxy/ProxyControllerSpec.scala
@@ -2,6 +2,7 @@ package com.pagerduty.akka.http.proxy
 
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.pagerduty.akka.http.support.RequestMetadata
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FreeSpecLike, Matchers}
 
@@ -17,8 +18,8 @@ class ProxyControllerSpec
     val expectedResponse = HttpResponse(201)
 
     val httpStub = new HttpProxy[String](null, null)(null, null, null) {
-      override def request(request: HttpRequest,
-                           upstream: Upstream[String]): Future[HttpResponse] =
+      override def request(request: HttpRequest, upstream: Upstream[String])(
+          implicit reqMeta: RequestMetadata): Future[HttpResponse] =
         Future.successful(expectedResponse)
     }
     val c = new ProxyController[String] {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.25.0"
+version in ThisBuild := "0.26.0-RC1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.26.0-RC1"
+version in ThisBuild := "0.26.0-RC2"


### PR DESCRIPTION
Adds support in `HttpProxy` for proxying WebSockets. Incoming web socket requests are automatically detected and proxied to the appropriate upstream.

Also added upstream response code metrics.

Had to pass around `RequestMetadata` a fair bit more to get logging in `HttpProxy` which was a little annoying... we should keep an eye on this and improve it if possible.

Also wasn't super happy with the tests. Had to resort to integration testing for the WebSocket proxy portion. But, it's relatively effective and did catch a bug.