### PR TITLE
CORE-1969 Bump Akka HTTP to 10.1.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 lazy val akkaVersion = "2.5.9"
-lazy val akkaHttpVersion = "10.0.11"
+lazy val akkaHttpVersion = "10.1.7"
 lazy val scalaMetricsVersion = "2.0.0"
 lazy val scalaTestVersion = "3.0.4"
 lazy val scalaMockVersion = "4.1.0"
@@ -45,6 +45,7 @@ lazy val arrivals =
         "com.lihaoyi" %% "ujson" % "0.6.6",
         "com.pagerduty" %% "metrics-api" % scalaMetricsVersion,
         "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % "test",
+        "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % "test",
         "org.scalamock" %% "scalamock" % scalaMockVersion % "test",
         "org.scalatest" %% "scalatest" % scalaTestVersion % "test,it",
         "ch.qos.logback" % "logback-classic" % logbackVersion % "test,it",

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-lazy val akkaVersion = "2.5.9"
+lazy val akkaVersion = "2.5.19"
 lazy val akkaHttpVersion = "10.1.7"
 lazy val scalaMetricsVersion = "2.0.0"
 lazy val scalaTestVersion = "3.0.4"

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val logbackVersion = "1.2+"
 
 lazy val sharedSettings = Seq(
   organization := "com.pagerduty",
-  scalaVersion := "2.12.5",
+  scalaVersion := "2.12.8",
   licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html")),
   bintrayOrganization := Some("pagerduty"),
   bintrayRepository := "oss-maven",

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val akkaHttpVersion = "10.1.7"
 lazy val scalaMetricsVersion = "2.0.0"
 lazy val scalaTestVersion = "3.0.4"
 lazy val scalaMockVersion = "4.1.0"
-lazy val akkaSupportHttpVersion = "0.6.4"
+lazy val akkaSupportHttpVersion = "0.7.1"
 lazy val logbackVersion = "1.2+"
 
 lazy val sharedSettings = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.17

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.33.0"
+version in ThisBuild := "0.34.0"


### PR DESCRIPTION
We also bump:
- Scala to 2.12.8
- SBT to 0.13.17
- Akka to 2.5.19
- akka-support-http to 0.7.1