### PR TITLE
Simplify authentication by removing separate credential extraction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,3 @@ This library is maintained by the Core team at PagerDuty. Opening a GitHub issue
 - Docs and examples
 - Metadata logging is inconsistently used because it's a PITA - would be nice to do something less ugly and not include `akka-http-support` in `arrivals-api`
 - De-couple authentication and authorization
-- Allow for customizeable handling of multiple credentials

--- a/arrivals-api/src/main/scala/com/pagerduty/arrivals/api/auth/AuthenticationConfig.scala
+++ b/arrivals-api/src/main/scala/com/pagerduty/arrivals/api/auth/AuthenticationConfig.scala
@@ -7,13 +7,10 @@ import scala.concurrent.Future
 import scala.util.Try
 
 trait AuthenticationConfig {
-  type Cred
   type AuthData
   type Permission
 
-  def extractCredentials(request: HttpRequest)(implicit reqMeta: RequestMetadata): List[Cred]
-
-  def authenticate(credential: Cred)(implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]]
+  def authenticate(request: HttpRequest)(implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]]
 
   def authDataGrantsPermission(
       authData: AuthData,

--- a/arrivals-example/src/main/scala/com/pagerduty/arrivals/example/ExampleAuthConfig.scala
+++ b/arrivals-example/src/main/scala/com/pagerduty/arrivals/example/ExampleAuthConfig.scala
@@ -10,21 +10,17 @@ import scala.concurrent.Future
 import scala.util.{Success, Try}
 
 class ExampleAuthConfig extends HeaderAuthConfig {
-  type Cred = String
   type AuthData = UserId
   type Permission = Nothing
 
-  def extractCredentials(request: HttpRequest)(implicit reqMeta: RequestMetadata): List[Cred] = {
-    // obviously, this is a terrible, terrible idea that you should never do
-    request.uri.query().get("username").toList
-  }
+  def authenticate(request: HttpRequest)(implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]] = {
+    // obviously, this method is a terrible, terrible idea that you should never do
+    val username = request.uri.query().get("username")
 
-  def authenticate(credential: Cred)(implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]] = {
-    // for demo purposes.... don't do this
-    Future.successful(Success(credential match {
-      case "mittens" => Some(1)
-      case "rex"     => Some(2)
-      case _         => None
+    Future.successful(Success(username match {
+      case Some("mittens") => Some(1)
+      case Some("rex")     => Some(2)
+      case _               => None
     }))
   }
 

--- a/arrivals/src/test/scala/com/pagerduty/arrivals/impl/aggregator/AggregatorRoutesSpec.scala
+++ b/arrivals/src/test/scala/com/pagerduty/arrivals/impl/aggregator/AggregatorRoutesSpec.scala
@@ -20,19 +20,16 @@ class AggregatorRoutesSpec extends FreeSpecLike with Matchers with MockFactory w
   val testAuthData = "auth-data"
 
   class TestAuthConfig extends HeaderAuthConfig {
-    type Cred = String
     type AuthData = String
     type Permission = String
 
-    def extractCredentials(request: HttpRequest)(implicit reqMeta: RequestMetadata): List[Cred] =
+    def authenticate(request: HttpRequest)(implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]] = {
       if (request.uri.toString.contains("failed-auth")) {
-        List()
+        Future.successful(Success(None))
       } else {
-        List("credential")
+        Future.successful(Success(Some(testAuthData)))
       }
-
-    def authenticate(credential: Cred)(implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]] =
-      Future.successful(Success(Some(testAuthData)))
+    }
 
     def authDataGrantsPermission(
         authData: AuthData,

--- a/arrivals/src/test/scala/com/pagerduty/arrivals/impl/aggregator/support/TestAuthConfig.scala
+++ b/arrivals/src/test/scala/com/pagerduty/arrivals/impl/aggregator/support/TestAuthConfig.scala
@@ -10,14 +10,11 @@ import scala.concurrent.Future
 import scala.util.Try
 
 class TestAuthConfig extends HeaderAuthConfig {
-  type Cred = String
   type AuthData = String
   type Permission = String
   type AuthHeader = RawHeader
 
-  def extractCredentials(request: HttpRequest)(implicit reqMeta: RequestMetadata): List[Cred] = ???
-
-  def authenticate(credential: Cred)(implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]] = ???
+  def authenticate(request: HttpRequest)(implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]] = ???
 
   def authDataGrantsPermission(
       authData: AuthData,

--- a/arrivals/src/test/scala/com/pagerduty/arrivals/impl/authproxy/AuthProxyRoutesSpec.scala
+++ b/arrivals/src/test/scala/com/pagerduty/arrivals/impl/authproxy/AuthProxyRoutesSpec.scala
@@ -24,13 +24,10 @@ class AuthProxyRoutesSpec extends FreeSpecLike with Matchers with ScalatestRoute
   val testAuthData = "auth-data"
 
   class TestAuthConfig extends HeaderAuthConfig {
-    type Cred = String
     type AuthData = String
     type Permission = String
 
-    def extractCredentials(request: HttpRequest)(implicit reqMeta: RequestMetadata): List[Cred] = List("credential")
-
-    def authenticate(credential: Cred)(implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]] =
+    def authenticate(request: HttpRequest)(implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]] =
       Future.successful(Success(Some(testAuthData)))
 
     def authDataGrantsPermission(

--- a/arrivals/src/test/scala/com/pagerduty/arrivals/impl/headerauth/AuthHeaderDirectivesSpec.scala
+++ b/arrivals/src/test/scala/com/pagerduty/arrivals/impl/headerauth/AuthHeaderDirectivesSpec.scala
@@ -14,13 +14,10 @@ import scala.util.Try
 
 class AuthHeaderDirectivesSpec extends FreeSpec with Matchers with ScalatestRouteTest {
   class TestAuthConfig extends HeaderAuthConfig {
-    type Cred = String
     type AuthData = String
     type Permission = String
 
-    def extractCredentials(request: HttpRequest)(implicit reqMeta: RequestMetadata): List[Cred] = ???
-
-    def authenticate(credential: Cred)(implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]] =
+    def authenticate(request: HttpRequest)(implicit reqMeta: RequestMetadata): Future[Try[Option[AuthData]]] =
       ???
 
     def authDataGrantsPermission(

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.34.0"
+version in ThisBuild := "0.35.0"


### PR DESCRIPTION
There were a couple problems with the existing `AuthenticationConfig`:

- The behaviour when multiple credentials were extracted was hard-coded to be "deny authentication"
- Some authentication schemes may require consuming the request body (e.g. if the body is signed with HMAC). This meant that either the request needed to be provided to `authenticate`, or `extractCredentials` needed to return a `Future`.
- `Cred` is not a great name!

To solve all of these things, this PR combines `extractCredentials` and `authenticate` into a single method. This simplifies `AuthenticationConfig` considerably (one less type member, one less method to implement), it gives more flexibility about multi-cred behaviour, and it allows for more complex auth schemes that require body consumption.