### PR TITLE
Stream upstream response to client on demand

### DIFF
--- a/arrivals-example/src/main/resources/application.conf
+++ b/arrivals-example/src/main/resources/application.conf
@@ -36,6 +36,10 @@ akka {
       max-to-strict-bytes = 32m
     }
     host-connection-pool {
+      # This is the default pool in Akka HTTP 10.1.x. Do not use `legacy` since it will cause connection pool leakage due to the occasionally
+      # unconsumed upstream response.
+      pool-implementation = new
+
       # Some proxy upstreams will need many connections. Since these connections are frequently cleaned up
       # and don't eat up resources, there's no need to lower this limit.
       max-connections = 512

--- a/arrivals/src/main/scala/com/pagerduty/arrivals/proxy/HttpProxy.scala
+++ b/arrivals/src/main/scala/com/pagerduty/arrivals/proxy/HttpProxy.scala
@@ -86,9 +86,7 @@ class HttpProxy[AddressingConfig](
   private def proxyHttpRequest(request: HttpRequest, upstream: Upstream[AddressingConfig]): Future[HttpResponse] = {
     val response = httpClient.executeRequest(request)
     response.flatMap { r =>
-      r.entity.withoutSizeLimit().toStrict(entityConsumptionTimeout).flatMap { e =>
-        upstream.responseFilter(request, r.withEntity(e), ())
-      }
+      upstream.responseFilter(request, r, ())
     }
   }
 

--- a/arrivals/src/main/scala/com/pagerduty/arrivals/proxy/HttpProxy.scala
+++ b/arrivals/src/main/scala/com/pagerduty/arrivals/proxy/HttpProxy.scala
@@ -44,8 +44,7 @@ object HttpProxy {
   */
 class HttpProxy[AddressingConfig](
     addressingConfig: AddressingConfig,
-    httpClient: HttpClient,
-    entityConsumptionTimeout: FiniteDuration = 20.seconds
+    httpClient: HttpClient
   )(implicit ec: ExecutionContext,
     materializer: Materializer,
     metrics: Metrics)

--- a/arrivals/src/test/scala/com/pagerduty/arrivals/aggregator/AggregatorSpec.scala
+++ b/arrivals/src/test/scala/com/pagerduty/arrivals/aggregator/AggregatorSpec.scala
@@ -118,7 +118,7 @@ class AggregatorSpec
 
     "short-circuits if the initial handler returns a response" in {
       implicit val stubProxy =
-        new HttpProxy[String](null, null, null)(null, null, null)
+        new HttpProxy[String](null, null)(null, null, null)
 
       val request = HttpRequest(HttpMethods.POST)
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.36.2"
+version in ThisBuild := "0.37.0-RC1"


### PR DESCRIPTION
Previously, the `HttpProxy` eagerly consumed the upstream response before streaming it to the client. This was necessary because it was never guaranteed that the client would consume the whole response and thus pull it through the connection slot. If the response was not consumed, the upstream would be backpressured and the connection slot was never released back to the pool. Eventually the API gateway would run out of connection slots.

In Akka HTTP 10.1.x, the new connection pool implementation automatically clears any slot that doesn't have its entity consumed. See `response-entity-subscription-timeout` for a description of this mechanism on https://doc.akka.io/docs/akka-http/current/configuration.html.

Streaming the response continuously, instead of eagerly consuming it and then streaming it to the client, is preferable from both a memory consumption and response latency point of view.

RC release for now, to go through testing.