### PR TITLE
Update dependencies & deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ All Arrivals routes have an `implicit` dependency on an `ArrivalsContext`.
 
 ``` scala
 implicit val system = ActorSystem()
-implicit val mat = ActorMaterializer()
-
 implicit val arrivalsCtx = ArrivalsContext("localhost") // "localhost" is the hostname for all upstreams in this example
 ```
 
@@ -90,8 +88,8 @@ You must provide an `AddressingConfig`, which is a piece of data used by the pro
 
 In the event that you do not require this data, you can pass `Unit`.
 
-Because everything in Arrivals is Akka-based, you must implicitly provide the usual Akka `ActorSystem`
-and `Materializer`. A `Metrics` provider is optional and defaults to a no-op metrics implementation.
+Because everything in Arrivals is Akka-based, you must implicitly provide the usual Akka `ActorSystem`.
+A `Metrics` provider is optional and defaults to a no-op metrics implementation.
 
 #### Declare an `Upstream`
 

--- a/arrivals-example/src/main/scala/com/pagerduty/arrivals/example/ExampleApp.scala
+++ b/arrivals-example/src/main/scala/com/pagerduty/arrivals/example/ExampleApp.scala
@@ -3,7 +3,6 @@ package com.pagerduty.arrivals.example
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.StatusCodes
-import akka.stream.ActorMaterializer
 import akka.http.scaladsl.server.Directives._
 import com.pagerduty.arrivals.ArrivalsContext
 import com.pagerduty.arrivals.aggregator.AggregatorRoutes
@@ -16,7 +15,6 @@ import scala.io.StdIn
 object ExampleApp extends App {
   implicit val system = ActorSystem()
   implicit val ec = system.dispatcher
-  implicit val mat = ActorMaterializer()
 
   import ExampleUpstream._
 

--- a/arrivals/src/it/scala/com/pagerduty/arrivals/authproxy/AuthProxyBehaviourSpec.scala
+++ b/arrivals/src/it/scala/com/pagerduty/arrivals/authproxy/AuthProxyBehaviourSpec.scala
@@ -245,8 +245,7 @@ class AuthProxyBehaviourSpec extends IntegrationSpec {
           HttpResponse(404, entity = "Unknown resource!")
       }
 
-      val bindingFuture =
-        Http().bindAndHandleSync(requestHandler, interface = "localhost", port = 10100)
+      val bindingFuture = Http().newServerAt("localhost", 10100).bindSync(requestHandler)
 
       // a simple WebSocket client
       val sink = Sink.head[Message]

--- a/arrivals/src/it/scala/com/pagerduty/arrivals/authproxy/AuthProxyBehaviourSpec.scala
+++ b/arrivals/src/it/scala/com/pagerduty/arrivals/authproxy/AuthProxyBehaviourSpec.scala
@@ -1,8 +1,8 @@
 package com.pagerduty.arrivals.authproxy
 
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.ws.{Message, TextMessage, UpgradeToWebSocket, WebSocketRequest}
-import akka.http.scaladsl.model.{HttpMethods, HttpRequest, HttpResponse, Uri}
+import akka.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, HttpResponse, Uri, AttributeKeys}
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import com.github.tomakehurst.wiremock.http.Fault
 import com.pagerduty.arrivals.authproxy.support.{IntegrationSpec, TestAuthConfig}
@@ -234,7 +234,7 @@ class AuthProxyBehaviourSpec extends IntegrationSpec {
 
       val requestHandler: HttpRequest => HttpResponse = {
         case req @ HttpRequest(HttpMethods.GET, Uri.Path("/ws"), _, _, _) =>
-          req.header[UpgradeToWebSocket] match {
+          req.attribute(AttributeKeys.webSocketUpgrade) match {
             case Some(upgrade) =>
               upgrade.handleMessages(stubWebSocketService)
             case None =>

--- a/arrivals/src/it/scala/com/pagerduty/arrivals/authproxy/support/IntegrationSpec.scala
+++ b/arrivals/src/it/scala/com/pagerduty/arrivals/authproxy/support/IntegrationSpec.scala
@@ -8,12 +8,14 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import com.pagerduty.arrivals.proxy.{HttpClient, HttpProxy}
 import com.pagerduty.metrics.NullMetrics
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FreeSpecLike, Matchers}
+import org.scalatest.freespec.AnyFreeSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
 
-trait IntegrationSpec extends FreeSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
+trait IntegrationSpec extends AnyFreeSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
 
   val host = "localhost"
   val port = 1234

--- a/arrivals/src/it/scala/com/pagerduty/arrivals/authproxy/support/IntegrationSpec.scala
+++ b/arrivals/src/it/scala/com/pagerduty/arrivals/authproxy/support/IntegrationSpec.scala
@@ -3,7 +3,6 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.ws.{Message, WebSocketRequest}
 import akka.http.scaladsl.{Http, HttpExt}
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
@@ -26,7 +25,6 @@ trait IntegrationSpec extends FreeSpecLike with Matchers with BeforeAndAfterAll 
   val servicePort = 3456
 
   implicit var as: ActorSystem = _
-  implicit var m: ActorMaterializer = _
   implicit var ec: ExecutionContext = _
   var http: HttpExt = _
   var s: HttpServer = _
@@ -36,7 +34,6 @@ trait IntegrationSpec extends FreeSpecLike with Matchers with BeforeAndAfterAll 
   override def beforeAll(): Unit = {
     as = ActorSystem("bff-public-api-test")
     ec = as.dispatcher
-    m = ActorMaterializer()
     implicit val metrics = NullMetrics
     http = Http()
 
@@ -74,7 +71,6 @@ trait IntegrationSpec extends FreeSpecLike with Matchers with BeforeAndAfterAll 
     s.stop()
     mockService.stop()
     mockAs.stop()
-    m.shutdown()
     Await.ready(as.terminate(), Duration.Inf)
     ()
   }

--- a/arrivals/src/main/scala/com/pagerduty/arrivals/proxy/HttpProxy.scala
+++ b/arrivals/src/main/scala/com/pagerduty/arrivals/proxy/HttpProxy.scala
@@ -1,7 +1,7 @@
 package com.pagerduty.arrivals.proxy
 
 import akka.http.scaladsl.model.ws._
-import akka.http.scaladsl.model.{HttpHeader, HttpRequest, HttpResponse}
+import akka.http.scaladsl.model.{HttpHeader, HttpRequest, HttpResponse, AttributeKeys}
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import com.pagerduty.akka.http.support.{MetadataLogging, RequestMetadata}
@@ -68,7 +68,7 @@ class HttpProxy[AddressingConfig](
       case Right(filteredRequest) =>
         val stopwatch = Stopwatch.start()
 
-        val response = filteredRequest.header[UpgradeToWebSocket] match {
+        val response = filteredRequest.attribute(AttributeKeys.webSocketUpgrade) match {
           case Some(upgrade) =>
             proxyWebSocketRequest(filteredRequest, upgrade, upstream)
           case None =>
@@ -94,7 +94,7 @@ class HttpProxy[AddressingConfig](
 
   private def proxyWebSocketRequest(
       request: HttpRequest,
-      upgrade: UpgradeToWebSocket,
+      upgrade: WebSocketUpgrade,
       upstream: Upstream[AddressingConfig]
     )(implicit reqMeta: RequestMetadata
     ): Future[HttpResponse] = {

--- a/arrivals/src/test/scala/com/pagerduty/arrivals/aggregator/AggregatorSpec.scala
+++ b/arrivals/src/test/scala/com/pagerduty/arrivals/aggregator/AggregatorSpec.scala
@@ -2,7 +2,7 @@ package com.pagerduty.arrivals.aggregator
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest, HttpResponse, StatusCodes}
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.testkit.TestKit
 import com.pagerduty.arrivals.aggregator.support.{TestAuthConfig, TestUpstream}
 import com.pagerduty.arrivals.api.proxy.Upstream
@@ -22,12 +22,13 @@ class AggregatorSpec
     with MockFactory
     with BeforeAndAfterAll {
 
-  override def afterAll {
+  override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
   }
 
   implicit val executionContext = ExecutionContext.global
-  implicit val materializer = ActorMaterializer()
+  implicit val actorSystem = ActorSystem()
+  implicit val materializer = Materializer.matFromSystem(actorSystem)
 
   val ac = new TestAuthConfig
 

--- a/arrivals/src/test/scala/com/pagerduty/arrivals/aggregator/OneStepJsonHydrationAggregatorSpec.scala
+++ b/arrivals/src/test/scala/com/pagerduty/arrivals/aggregator/OneStepJsonHydrationAggregatorSpec.scala
@@ -2,7 +2,7 @@ package com.pagerduty.arrivals.aggregator
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.testkit.TestKit
 import com.pagerduty.arrivals.aggregator.support.{TestAuthConfig, TestUpstream}
 import com.pagerduty.arrivals.api.aggregator.AggregatorUpstream
@@ -26,12 +26,13 @@ class OneStepJsonHydrationAggregatorSpec
     with ScalaFutures
     with BeforeAndAfterAll {
 
-  override def afterAll {
+  override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
   }
 
   implicit val executionContext = ExecutionContext.global
-  implicit val materializer = ActorMaterializer()
+  implicit val actorSystem = ActorSystem()
+  implicit val materializer = Materializer.matFromSystem(actorSystem)
 
   val ac = new TestAuthConfig
 

--- a/arrivals/src/test/scala/com/pagerduty/arrivals/aggregator/TwoStepJsonHydrationAggregatorSpec.scala
+++ b/arrivals/src/test/scala/com/pagerduty/arrivals/aggregator/TwoStepJsonHydrationAggregatorSpec.scala
@@ -2,7 +2,7 @@ package com.pagerduty.arrivals.aggregator
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.testkit.TestKit
 import com.pagerduty.arrivals.aggregator.support.{TestAuthConfig, TestUpstream}
 import com.pagerduty.arrivals.api.aggregator.AggregatorUpstream
@@ -24,12 +24,13 @@ class TwoStepJsonHydrationAggregatorSpec
     with MockFactory
     with BeforeAndAfterAll {
 
-  override def afterAll {
+  override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
   }
 
   implicit val executionContext = ExecutionContext.global
-  implicit val materializer = ActorMaterializer()
+  implicit val actorSystem = ActorSystem()
+  implicit val materializer = Materializer.matFromSystem(actorSystem)
 
   val ac = new TestAuthConfig
 

--- a/arrivals/src/test/scala/com/pagerduty/arrivals/proxy/HttpProxySpec.scala
+++ b/arrivals/src/test/scala/com/pagerduty/arrivals/proxy/HttpProxySpec.scala
@@ -5,7 +5,6 @@ import akka.http.scaladsl.model.Uri.Authority
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.ws.{Message, WebSocketRequest, WebSocketUpgradeResponse}
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
 import com.pagerduty.akka.http.support.RequestMetadata
 import com.pagerduty.arrivals.api.filter.{SyncRequestFilter, SyncResponseFilter}
@@ -60,7 +59,6 @@ class HttpProxySpec extends AnyFreeSpecLike with Matchers with ScalaFutures {
 
     import scala.concurrent.ExecutionContext.Implicits.global
     implicit val system = ActorSystem()
-    implicit val materializer = ActorMaterializer()
     implicit val metrics = NullMetrics
     val response = HttpResponse()
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.36.2"
+version in ThisBuild := "0.36.3"


### PR DESCRIPTION
Bump patch version

Deprecations
 - ActorMaterializer is now derived from ActorSystem
 - UpgradeToWebSocket is now an attribute on the request
 - bindAndHandleSync & bindAndHandle shortcuts are going away

Fix integration tests for scalatest reorganization.

Ran both suites of tests against both Scala 2.12.8 and 2.13.4, everything looked good :sparkles:
Ran the old CircleCi test suite and these were also fine